### PR TITLE
✨ feature: add link to paper inbox in conference model and UI

### DIFF
--- a/prisma/migrations/20250224161158_add_link_to_paper_inbox_field/migration.sql
+++ b/prisma/migrations/20250224161158_add_link_to_paper_inbox_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Conference" ADD COLUMN     "linkToPaperInbox" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Conference {
   imageDataURL           String?
   info                   String?
   linkToPreparationGuide String?
+  linkToPaperInbox       String?
   state                  ConferenceState @default(PRE)
   startAssignment        DateTime
   startConference        DateTime

--- a/schema.graphql
+++ b/schema.graphql
@@ -186,6 +186,7 @@ type Conference {
   individualApplicationOptions: [CustomConferenceRole!]!
   info: String
   language: String
+  linkToPaperInbox: String
   linkToPreparationGuide: String
   location: String
   longTitle: String
@@ -235,6 +236,7 @@ input ConferenceCreateInput {
   individualApplicationOptions: CustomConferenceRoleCreateNestedManyWithoutConferenceInput
   info: String
   language: String
+  linkToPaperInbox: String
   linkToPreparationGuide: String
   location: String
   longTitle: String
@@ -281,6 +283,7 @@ input ConferenceOrderByWithRelationInput {
   individualApplicationOptions: CustomConferenceRoleOrderByRelationAggregateInput
   info: SortOrder
   language: SortOrder
+  linkToPaperInbox: SortOrder
   linkToPreparationGuide: SortOrder
   location: SortOrder
   longTitle: SortOrder
@@ -475,6 +478,7 @@ enum ConferenceScalarFieldEnum {
   imageDataURL
   info
   language
+  linkToPaperInbox
   linkToPreparationGuide
   location
   longTitle
@@ -675,6 +679,7 @@ input ConferenceUpdateDataInput {
   image: File
   info: String
   language: String
+  linkToPaperInbox: String
   linkToPreparationGuide: String
   location: String
   longTitle: String
@@ -715,6 +720,7 @@ input ConferenceUpdateInput {
   individualApplicationOptions: CustomConferenceRoleUpdateManyWithoutConferenceNestedInput
   info: NullableStringFieldUpdateOperationsInput
   language: NullableStringFieldUpdateOperationsInput
+  linkToPaperInbox: NullableStringFieldUpdateOperationsInput
   linkToPreparationGuide: NullableStringFieldUpdateOperationsInput
   location: NullableStringFieldUpdateOperationsInput
   longTitle: NullableStringFieldUpdateOperationsInput
@@ -755,6 +761,7 @@ input ConferenceUpdateManyMutationInput {
   imageDataURL: NullableStringFieldUpdateOperationsInput
   info: NullableStringFieldUpdateOperationsInput
   language: NullableStringFieldUpdateOperationsInput
+  linkToPaperInbox: NullableStringFieldUpdateOperationsInput
   linkToPreparationGuide: NullableStringFieldUpdateOperationsInput
   location: NullableStringFieldUpdateOperationsInput
   longTitle: NullableStringFieldUpdateOperationsInput
@@ -799,6 +806,7 @@ input ConferenceWhereInput {
   individualApplicationOptions: CustomConferenceRoleListRelationFilter
   info: StringNullableFilter
   language: StringNullableFilter
+  linkToPaperInbox: StringNullableFilter
   linkToPreparationGuide: StringNullableFilter
   location: StringNullableFilter
   longTitle: StringNullableFilter
@@ -848,6 +856,7 @@ input ConferenceWhereUniqueInput {
   individualApplicationOptions: CustomConferenceRoleListRelationFilter
   info: StringNullableFilter
   language: StringNullableFilter
+  linkToPaperInbox: StringNullableFilter
   linkToPreparationGuide: StringNullableFilter
   location: StringNullableFilter
   longTitle: StringNullableFilter

--- a/src/api/resolvers/modules/conference/conference.ts
+++ b/src/api/resolvers/modules/conference/conference.ts
@@ -12,6 +12,7 @@ import {
 	ConferenceImageDataURLFieldObject,
 	ConferenceInfoFieldObject,
 	ConferenceLanguageFieldObject,
+	ConferenceLinkToPaperInboxFieldObject,
 	ConferenceLinkToPreparationGuideFieldObject,
 	ConferenceLocationFieldObject,
 	ConferenceLongTitleFieldObject,
@@ -46,6 +47,7 @@ builder.prismaObject('Conference', {
 		title: t.field(ConferenceTitleFieldObject),
 		info: t.field(ConferenceInfoFieldObject),
 		linkToPreparationGuide: t.field(ConferenceLinkToPreparationGuideFieldObject),
+		linkToPaperInbox: t.field(ConferenceLinkToPaperInboxFieldObject),
 		longTitle: t.field(ConferenceLongTitleFieldObject),
 		location: t.field(ConferenceLocationFieldObject),
 		language: t.field(ConferenceLanguageFieldObject),
@@ -196,6 +198,9 @@ builder.mutationFields((t) => {
 								required: false
 							}),
 							linkToPreparationGuide: t.string({
+								required: false
+							}),
+							linkToPaperInbox: t.string({
 								required: false
 							}),
 							longTitle: t.string({

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -628,5 +628,8 @@
 	"surveyOpen": "Umfrage bis {deadline} geöffnet",
 	"optionUpperLimitReached": "Auswahl konnte nicht bestätigt werden, da die Maximalanzahl bereits erreicht wurde.",
 	"questionDeadlinePassed": "Die Umfrage ist bereits abgelaufen und kann nicht mehr ausgefüllt werden.",
-	"noUpperLimit": "Keine Begrenzung"
+	"noUpperLimit": "Keine Begrenzung",
+	"paperInbox": "Link zum Einreichen von Papieren",
+	"paperInboxDescription": "Über das hinterlegte Formular kannst du Positions- und Arbeitspapiere einreichen.",
+	"paperInboxBtn": "Papier einreichen"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -573,5 +573,8 @@
 	"surveyOpen": "Survey open until {deadline}",
 	"optionUpperLimitReached": "Selection could not be confirmed because the maximum number has already been reached.",
 	"questionDeadlinePassed": "The survey has already expired and can no longer be completed.",
-	"noUpperLimit": "No Upper Limit"
+	"noUpperLimit": "No Upper Limit",
+	"paperInbox": "Link to Submit Papers",
+	"paperInboxDescription": "You can submit position and working papers using the form provided.",
+	"paperInboxBtn": "Submit Paper"
 }

--- a/src/lib/queries/myConferenceparticipationQuery.ts
+++ b/src/lib/queries/myConferenceparticipationQuery.ts
@@ -20,6 +20,7 @@ export const myConferenceparticipationQuery = graphql(`
 			title
 			info
 			linkToPreparationGuide
+			linkToPaperInbox
 			state
 			startConference
 			startAssignment

--- a/src/lib/services/paperInboxLink.ts
+++ b/src/lib/services/paperInboxLink.ts
@@ -1,0 +1,10 @@
+export default function generatePaperInboxLinkWithParams(
+	baseLink: string,
+	user: {
+		sub: string;
+		email: string;
+	}
+) {
+	const extensions = `userId=${encodeURIComponent(user.sub)}&email=${encodeURIComponent(user.email)}`;
+	return `${baseLink}?${extensions}`;
+}

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/DelegationPreparationStage.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/DelegationPreparationStage.svelte
@@ -11,6 +11,7 @@
 	import formatNames from '$lib/services/formatNames';
 	import getSimplifiedPostalStatus from '$lib/services/getSimplifiedPostalStatus';
 	import { ofAgeAtConference } from '$lib/services/ageChecker';
+	import generatePaperInboxLinkWithParams from '$lib/services/paperInboxLink';
 
 	let {
 		data
@@ -72,6 +73,20 @@
 			btnText={m.goToPreparation()}
 			btnLink={data.findUniqueConference?.linkToPreparationGuide}
 			btnExternal
+		/>
+	{/if}
+	{#if data.findUniqueConference?.linkToPaperInbox && data.user}
+		<TaskAlertCard
+			faIcon="fa-file-circle-plus"
+			title={m.paperInbox()}
+			description={m.paperInboxDescription()}
+			btnText={m.paperInboxBtn()}
+			btnLink={generatePaperInboxLinkWithParams(
+				data.findUniqueConference?.linkToPaperInbox,
+				data.user
+			)}
+			btnExternal
+			severity="info"
 		/>
 	{/if}
 </TasksWrapper>

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipantPreparationStage.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipantPreparationStage.svelte
@@ -7,6 +7,7 @@
 	import TasksWrapper from '$lib/components/TasksAlert/TasksWrapper.svelte';
 	import TaskAlertCard from '$lib/components/TasksAlert/TaskAlertCard.svelte';
 	import formatNames from '$lib/services/formatNames';
+	import generatePaperInboxLinkWithParams from '$lib/services/paperInboxLink';
 
 	let {
 		data
@@ -47,6 +48,20 @@
 			btnText={m.goToPreparation()}
 			btnLink={data.findUniqueConference?.linkToPreparationGuide}
 			btnExternal
+		/>
+	{/if}
+	{#if data.findUniqueConference?.linkToPaperInbox && data.user}
+		<TaskAlertCard
+			faIcon="fa-file-circle-plus"
+			title={m.paperInbox()}
+			description={m.paperInboxDescription()}
+			btnText={m.paperInboxBtn()}
+			btnLink={generatePaperInboxLinkWithParams(
+				data.findUniqueConference?.linkToPaperInbox,
+				data.user
+			)}
+			btnExternal
+			severity="info"
 		/>
 	{/if}
 </TasksWrapper>

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.server.ts
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.server.ts
@@ -21,6 +21,7 @@ const conferenceQuery = graphql(`
 			imageDataURL
 			language
 			linkToPreparationGuide
+			linkToPaperInbox
 			info
 			unlockPayments
 			unlockPostals

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.svelte
@@ -111,6 +111,12 @@
 			placeholder={'https://path-to-your-guide.com'}
 			label={m.preparationGuide()}
 		/>
+		<FormTextInput
+			{form}
+			name="linkToPaperInbox"
+			placeholder={'https://path-to-your-paper-inbox.com'}
+			label={m.paperInbox()}
+		/>
 
 		<h3 class="mt-8 text-lg font-bold">{m.bankingInformation()}</h3>
 		<FormCheckbox

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/form-schema.ts
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/form-schema.ts
@@ -9,6 +9,7 @@ export const conferenceSettingsFormSchema = z.object({
 	}),
 	info: z.string().nullish(),
 	linkToPreparationGuide: z.string().nullish(),
+	linkToPaperInbox: z.string().nullish(),
 	longTitle: z
 		.string()
 		.min(5, {


### PR DESCRIPTION
This pull request introduces a new field, `linkToPaperInbox`, to the `Conference` model, schema, and various parts of the application. The changes ensure that the new field is integrated into the database, GraphQL schema, and front-end components.

Database and Model Changes:
* Added `linkToPaperInbox` field to the `Conference` table in the database schema (`prisma/migrations/20250224161158_add_link_to_paper_inbox_field/migration.sql`).
* Updated `Conference` model in `prisma/schema.prisma` to include the new `linkToPaperInbox` field.

GraphQL Schema Updates:
* Added `linkToPaperInbox` field to the `Conference` type and various input types in the GraphQL schema (`schema.graphql`). [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R189) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R239) [[3]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R286) [[4]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R481) [[5]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R682) [[6]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R723) [[7]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R764) [[8]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R809) [[9]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R859)

Front-End Integration:
* Added `linkToPaperInbox` field to the conference resolver and mutation fields in `src/api/resolvers/modules/conference/conference.ts`. [[1]](diffhunk://#diff-b07c779bf1f1002bfc92cdcf27758a8a34d70d289f087ac05826729ce0e9976eR15) [[2]](diffhunk://#diff-b07c779bf1f1002bfc92cdcf27758a8a34d70d289f087ac05826729ce0e9976eR50) [[3]](diffhunk://#diff-b07c779bf1f1002bfc92cdcf27758a8a34d70d289f087ac05826729ce0e9976eR203-R205)
* Updated language files to include new strings related to the paper inbox (`src/i18n/de.json`, `src/i18n/en.json`). [[1]](diffhunk://#diff-602aacb11a9e565a0c5ad0439241fd771f0f2f6e71dc228b7133a67a9ceaa483L631-R634) [[2]](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31L576-R579)
* Added `linkToPaperInbox` field to GraphQL queries and updated front-end components to display the paper inbox link (`src/lib/queries/myConferenceparticipationQuery.ts`, `src/routes/(authenticated)/dashboard/[conferenceId]/stages/DelegationPreparationStage.svelte`, `src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipantPreparationStage.svelte`, `src/routes/(authenticated)/management/[conferenceId]/configuration/+page.server.ts`, `src/routes/(authenticated)/management/[conferenceId]/configuration/+page.svelte`). ([src/lib/queries/myConferenceparticipationQuery.tsR23](diffhunk://#diff-ab3bedaf4077134c3f679f9695391c8fd4b820cc015ec7bc6a1ae815384b1513R23), [src/routes/(authenticated)/dashboard/[conferenceId]/stages/DelegationPreparationStage.svelteR14](diffhunk://#diff-3078bd20b29fba473e1e1c90b1eec71b0807efeb201e97348de132cc42f59ea5R14), [src/routes/(authenticated)/dashboard/[conferenceId]/stages/DelegationPreparationStage.svelteR78-R91](diffhunk://#diff-3078bd20b29fba473e1e1c90b1eec71b0807efeb201e97348de132cc42f59ea5R78-R91), [src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipantPreparationStage.svelteR10](diffhunk://#diff-fea781fee96722b77db9f69532efe8cf5f5d329ff4f29e6efbac8d3594a1cad8R10), [src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipantPreparationStage.svelteR53-R66](diffhunk://#diff-fea781fee96722b77db9f69532efe8cf5f5d329ff4f29e6efbac8d3594a1cad8R53-R66), [src/routes/(authenticated)/management/[conferenceId]/configuration/+page.server.tsR24](diffhunk://#diff-473654de03876dccf90468a34d7a4d9d1ecbaf1099c448e78840cde0458def44R24), [src/routes/(authenticated)/management/[conferenceId]/configuration/+page.svelteR114-R119](diffhunk://#diff-768c4c11a3796d0f399e7851931357ebcedc589851585559d6d9fa058cf9799aR114-R119))

New Utility Function:
* Created a utility function `generatePaperInboxLinkWithParams` to generate a link with user-specific parameters (`src/lib/services/paperInboxLink.ts`).