### PR TITLE
🚀 Enhancement: Add 403 lockout for management pages

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -438,6 +438,7 @@
 	"newsletters": "Newsletter",
 	"next": "Weiter",
 	"no": "Nein",
+	"noAccess": "Hier hast du keinen Zugriff",
 	"noAnswer": "Keine Antwort",
 	"noAnswerYet": "Noch nicht beantwortet",
 	"noCommittees": "Keine Gremien",

--- a/messages/en.json
+++ b/messages/en.json
@@ -438,6 +438,7 @@
 	"newsletters": "Newsletter",
 	"next": "Next",
 	"no": "No",
+	"noAccess": "You don't have access to this page.",
 	"noAnswer": "No Answer",
 	"noAnswerYet": "Not yet answered",
 	"noCommittees": "No Committees",

--- a/src/routes/(authenticated)/management/+layout.ts
+++ b/src/routes/(authenticated)/management/+layout.ts
@@ -1,6 +1,8 @@
 import { graphql } from '$houdini';
 import { allConferenceQuery } from '$lib/queries/allConferences';
-import type { PageLoad } from './$types';
+import { error } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
+import { m } from '$lib/paraglide/messages';
 
 const conferencesWhereImMoreThanMember = graphql(`
 	query ConferencesWhereImMoreThanMember($myUserId: String!) {
@@ -28,7 +30,7 @@ const conferencesWhereImMoreThanMember = graphql(`
 	}
 `);
 
-export const load: PageLoad = async (event) => {
+export const load: LayoutLoad = async (event) => {
 	const { user } = await event.parent();
 
 	// we want the conferences to appear either if we are a privileged user on that conference or
@@ -53,6 +55,11 @@ export const load: PageLoad = async (event) => {
 		blocking: true
 	});
 	const queriedConfernces = data?.findManyConferences;
+
+	if (queriedConfernces.length === 0) {
+		error(403, m.noAccess());
+	}
+
 	return {
 		conferences: queriedConfernces?.map((c) => ({
 			id: c.id,

--- a/src/routes/(authenticated)/management/[conferenceId]/+layout.ts
+++ b/src/routes/(authenticated)/management/[conferenceId]/+layout.ts
@@ -1,6 +1,13 @@
+import { error } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
+import { m } from '$lib/paraglide/messages';
 
 export const load: LayoutLoad = async (event) => {
+	const parentData = await event.parent();
+
+	if (!parentData.conferences.map((c) => c.id).includes(event.params.conferenceId))
+		error(403, m.noAccess());
+
 	return {
 		conferenceId: event.params.conferenceId
 	};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Management pages now enforce access restrictions. Users without permission are blocked with a 403 error page.
  - Added a localized “no access” message, displayed in English and German for clearer feedback.
  - Authorization checks ensure only conferences you’re allowed to access can be opened; unauthorized conference pages are denied.
  - Consistent access handling across management layouts provides a clearer, more secure experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->