### PR TITLE
fix: Handle undefined delegation ID in NSA assignment upsert

### DIFF
--- a/src/api/resolvers/modules/assignments.ts
+++ b/src/api/resolvers/modules/assignments.ts
@@ -393,7 +393,7 @@ builder.mutationFields((t) => {
 						// assign the nsa to the primary delegation and update the members and supervisors
 						const newOrExistingDelegation = await tx.delegation.upsert({
 							where: {
-								id: primaryDelegation?.id
+								id: primaryDelegation?.id ?? ''
 							},
 							update: {
 								assignedNonStateActor: {


### PR DESCRIPTION
## Summary
- Fixes a bug where assigning Non-State Actors (NSAs) to delegations failed when no existing delegation was found
- The `upsert` query received `id: undefined` instead of a valid fallback value
- Matches the existing pattern used for nation assignment on line 279

## Root Cause
When `delegationsDB` is empty (e.g., when converting single participants to delegations with NSA assignments), `primaryDelegation?.id` evaluates to `undefined`. Prisma's `upsert` requires a valid unique identifier in the `where` clause.

## Fix
Added `?? ''` fallback so an empty string (which won't match any record) causes Prisma to execute the `create` branch of the upsert.

## Test plan
- [x] Apply assignment data that includes NSA assignments for users without existing delegations
- [x] Verify the assignment completes without PrismaClientValidationError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved assignment delegation handling to properly create new delegations when no existing primary delegation is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->