### PR TITLE
fix (Frontend): resolve 1GB+ memory spike on survey detail page

### DIFF
--- a/src/routes/(authenticated)/management/[conferenceId]/survey/[surveyId]/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/survey/[surveyId]/+page.svelte
@@ -437,8 +437,7 @@
 				<SurveyExportButtons
 					surveyTitle={survey.title}
 					options={survey.options}
-					surveyAnswers={survey.surveyAnswers}
-					{notAnsweredParticipants}
+					surveyId={data.surveyId}
 					conferenceId={data.conferenceId}
 				/>
 			</DownloadCategoryCard>


### PR DESCRIPTION
## Summary

- Fixed massive memory spike (1GB+) on the survey detail page (`/management/[conferenceId]/survey/[surveyId]`)
- Root cause: GraphQL query was fetching ALL delegation memberships and single participant records for every user across ALL conferences, not just the current one
- With users participating in multiple conferences, this caused exponential data explosion

## Changes

1. **Simplified main query** - Now only fetches minimal user data (`id`, `given_name`, `family_name`) for display
2. **Replaced inefficient `findManyUsers`** - Now uses conference-filtered `findManyDelegationMembers` and `findManySingleParticipants` queries
3. **Added lazy export loading** - Full user data with role info is now fetched on-demand only when user clicks an export button

## Test plan

- [x] Visit `/management/[conferenceId]/survey/[surveyId]` with a survey that has many responses
- [x] Monitor browser memory (DevTools → Performance → Memory) - should stay under ~100MB
- [x] Verify charts render correctly
- [x] Verify participant lists display names correctly
- [x] Verify export buttons work and produce valid CSV files with role info

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized survey export functionality with improved data-fetching architecture and enhanced component structure for better performance and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->