### PR TITLE
fix (Backend): allow impersonation of conference supervisors

### DIFF
--- a/src/api/abilities/abilities.ts
+++ b/src/api/abilities/abilities.ts
@@ -117,6 +117,21 @@ export const defineAbilitiesForUser = (oidc: OIDC) => {
 							}
 						}
 					}
+				},
+				// Conference supervisors from conferences where user is team member
+				{
+					conferenceSupervisor: {
+						some: {
+							conference: {
+								teamMembers: {
+									some: {
+										user: { id: user.sub },
+										role: { in: ['PROJECT_MANAGEMENT', 'PARTICIPANT_CARE'] }
+									}
+								}
+							}
+						}
+					}
 				}
 			]
 		});

--- a/src/api/resolvers/modules/impersonation.ts
+++ b/src/api/resolvers/modules/impersonation.ts
@@ -131,6 +131,21 @@ builder.queryFields((t) => ({
 									}
 								}
 							}
+						},
+						// Conference supervisors from conferences where user is team member
+						{
+							conferenceSupervisor: {
+								some: {
+									conference: {
+										teamMembers: {
+											some: {
+												user: { id: user.sub },
+												role: { in: ['PROJECT_MANAGEMENT', 'PARTICIPANT_CARE'] }
+											}
+										}
+									}
+								}
+							}
 						}
 					]
 				},
@@ -207,6 +222,21 @@ builder.mutationFields((t) => ({
 							// Single participants from conferences where user is team member
 							{
 								singleParticipant: {
+									some: {
+										conference: {
+											teamMembers: {
+												some: {
+													user: { id: user.sub },
+													role: { in: ['PROJECT_MANAGEMENT', 'PARTICIPANT_CARE'] }
+												}
+											}
+										}
+									}
+								}
+							},
+							// Conference supervisors from conferences where user is team member
+							{
+								conferenceSupervisor: {
 									some: {
 										conference: {
 											teamMembers: {


### PR DESCRIPTION
The Stellvertretung (impersonation) feature was failing for supervisor
accounts with "No permission to impersonate this specific user" error.
This was because the permission checks only included delegation members
and single participants, but not conference supervisors (Betreuende).

Added conferenceSupervisor to the permission checks in:
- CASL abilities definition
- impersonatableUsers query
- startImpersonation mutation permission check

Fixes #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conference supervisors with Project Management or Participant Care team roles can now impersonate users within their conferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->