### PR TITLE
Avoid returning redundant review ID in mutation response

### DIFF
--- a/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/+page.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/+page.svelte
@@ -518,7 +518,7 @@
 				<fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-full border p-4">
 					<legend class="fieldset-legend">{m.history()}</legend>
 					<ul class="timeline timeline-vertical timeline-compact py-2">
-						{#each authorTimelineEvents as event, index}
+						{#each authorTimelineEvents as event, index (event.type === 'review' ? event.review.id : event.version.id)}
 							<li>
 								{#if index > 0}
 									<hr class="bg-base-300" />

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/PaperReviewSection.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/PaperReviewSection.svelte
@@ -367,7 +367,7 @@
 	<fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-full border p-4">
 		<legend class="fieldset-legend">{m.history()}</legend>
 		<ul class="timeline timeline-vertical timeline-compact py-2">
-			{#each timelineEvents as event, index}
+			{#each timelineEvents as event, index (event.type === 'review' ? event.review.id : event.version.id)}
 				<li class="">
 					{#if index > 0}
 						<hr class="bg-base-300" />


### PR DESCRIPTION
# Summary

  - Fixed duplicate review display bug in paper review history by removing unused review { id } from the CreatePaperReview mutation response
  - The returned PaperReview entity was causing Houdini to cache a partial review, which then duplicated with the full review data on refetch


# Test plan

  - Submit a paper review and verify it appears only once in the history timeline
  - Verify the "piece found" modal still works correctly when unlocking a flag piece
  - Reload the page and confirm the review history displays correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the paper review submission response by removing unneeded review metadata while keeping other response fields intact.
* **Bug Fixes**
  * Improved timeline rendering stability so mixed event items update more consistently and avoid visual update glitches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->