### PR TITLE
Fix create supervisor logic

### DIFF
--- a/src/api/resolvers/modules/conferenceSupervisor.ts
+++ b/src/api/resolvers/modules/conferenceSupervisor.ts
@@ -352,7 +352,7 @@ builder.mutationFields((t) => {
 					}
 				});
 
-				if (supervisor.userId !== user.sub || !user.hasRole('admin')) {
+				if (supervisor.userId !== user.sub && !user.hasRole('admin')) {
 					throw new GraphQLError('You are not allowed to rotate this connection code.');
 				}
 


### PR DESCRIPTION
Description
- Fix permission check in createOneConferenceSupervisor mutation: verify the current user's role (not the target user's) before allowing adding a supervisor.
- Align permission logic with singleParticipant.ts and delegationMember.ts resolvers.
- Fix small bug in supervisor code rotation logic.

Related issues / notes
- Fixes #336