### PR TITLE
Fix undefined getter error on dashboard back navigation

### DIFF
--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Supervisor/Supervisor.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Supervisor/Supervisor.svelte
@@ -307,9 +307,11 @@
 		</fieldset>
 	</div>
 	<p class="text-xs text-gray-500">
-		{@html supervisor.plansOwnAttendenceAtConference
-			? m.willBePresentAtConference()
-			: m.willNotBePresentAtConference()}
+		{#if supervisor.plansOwnAttendenceAtConference}
+			{@html m.willBePresentAtConference()}
+		{:else}
+			{@html m.willNotBePresentAtConference()}
+		{/if}
 	</p>
 </section>
 


### PR DESCRIPTION
Prevent calling undefined template getter by replacing ternary-style @html usage with an explicit if/else block. This change ensures first_child_getter is not accessed when supervisor.plansOwnAttendenceAtConference is falsy, avoiding the runtime TypeError when navigating back to /dashboard/id.