### PR TITLE
Validate TipTap content before passing to editor

### DIFF
--- a/src/lib/components/Paper/Editor/ReadOnlyContent.svelte
+++ b/src/lib/components/Paper/Editor/ReadOnlyContent.svelte
@@ -8,6 +8,7 @@
 	import Heading from '@tiptap/extension-heading';
 	import { m } from '$lib/paraglide/messages';
 	import type { Readable } from 'svelte/store';
+	import { getSafeTipTapContent } from './contentValidation';
 
 	interface Props {
 		content: any;
@@ -40,7 +41,7 @@
 					levels: [2, 3]
 				})
 			],
-			content: content || undefined,
+			content: getSafeTipTapContent(content),
 			editorProps: {
 				attributes: {
 					class: 'prose prose-sm focus:outline-none px-2'

--- a/src/lib/components/Paper/Editor/ReviewFormat.svelte
+++ b/src/lib/components/Paper/Editor/ReviewFormat.svelte
@@ -16,6 +16,7 @@
 	import PlaceholderPromptModal from './PlaceholderPromptModal.svelte';
 	import { extractPlaceholders, replacePlaceholders } from '$lib/services/snippetPlaceholders';
 	import type { JSONContent } from '@tiptap/core';
+	import { getSafeTipTapContent } from './contentValidation';
 
 	interface Props {
 		contentStore: Writable<any>;
@@ -147,7 +148,7 @@
 					onSelectSnippet: handleSnippetSelect
 				})
 			],
-			content: $contentStore || undefined,
+			content: getSafeTipTapContent($contentStore),
 			editorProps: {
 				attributes: {
 					class: 'prose prose-sm focus:outline-none p-3 min-h-[150px]'
@@ -163,8 +164,11 @@
 	// Clear editor when store is reset externally (e.g., after review submission)
 	$effect(() => {
 		const content = $contentStore;
-		// Only clear if store is empty object AND editor actually has content
-		if ($editor && content && Object.keys(content).length === 0 && !$editor.isEmpty) {
+		// Check if store contains an empty TipTap document (reset state)
+		const isEmptyDocument =
+			content?.type === 'doc' && (!content.content || content.content.length === 0);
+		// Only clear if store is empty document AND editor actually has content
+		if ($editor && isEmptyDocument && !$editor.isEmpty) {
 			$editor.commands.clearContent();
 		}
 	});

--- a/src/lib/components/Paper/Editor/contentValidation.ts
+++ b/src/lib/components/Paper/Editor/contentValidation.ts
@@ -1,0 +1,41 @@
+import type { JSONContent } from '@tiptap/core';
+
+/**
+ * Validates that content is a valid TipTap JSON structure.
+ * A valid TipTap document must have a `type` property.
+ * An empty/invalid content will cause TipTap to crash with:
+ * "TypeError: undefined is not an object (evaluating 'e(o).type')"
+ */
+export function isValidTipTapContent(content: unknown): content is JSONContent {
+	if (!content || typeof content !== 'object') {
+		return false;
+	}
+
+	// TipTap content must have a 'type' property
+	if (!('type' in content) || typeof (content as JSONContent).type !== 'string') {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Returns valid TipTap content or undefined if the content is invalid.
+ * Use this when passing content to TipTap editor to prevent crashes.
+ */
+export function getSafeTipTapContent(content: unknown): JSONContent | undefined {
+	if (isValidTipTapContent(content)) {
+		return content;
+	}
+	return undefined;
+}
+
+/**
+ * Returns an empty but valid TipTap document structure.
+ */
+export function getEmptyTipTapDocument(): JSONContent {
+	return {
+		type: 'doc',
+		content: []
+	};
+}

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/PaperReviewSection.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/PaperReviewSection.svelte
@@ -18,6 +18,7 @@
 	import { getStatusBadgeClass } from '$lib/services/paperStatusHelpers';
 	import { PieceFoundModal } from '$lib/components/FlagCollection';
 	import Modal from '$lib/components/Modal.svelte';
+	import { getEmptyTipTapDocument } from '$lib/components/Paper/Editor/contentValidation';
 
 	// Check if TipTap JSON content has any actual text
 	const hasContent = (content: any): boolean => {
@@ -182,7 +183,7 @@
 	};
 
 	// Review form state
-	let reviewComments = writable<any>({});
+	let reviewComments = writable<any>(getEmptyTipTapDocument());
 	let selectedStatus = $state<PaperStatus$options>(currentStatus);
 	let isSubmitting = $state(false);
 	let showConfirmModal = $state(false);
@@ -286,7 +287,7 @@
 			}
 
 			// Clear form
-			reviewComments.set({});
+			reviewComments.set(getEmptyTipTapDocument());
 
 			// Reload data
 			cache.markStale();

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/snippets/+page.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/snippets/+page.svelte
@@ -35,6 +35,10 @@
 	import Menu from '$lib/components/Paper/Editor/Menu';
 	import { validatePlaceholders } from '$lib/services/snippetPlaceholders';
 	import { PlaceholderHighlight } from '$lib/components/Paper/Editor/extensions/PlaceholderHighlight';
+	import {
+		isValidTipTapContent,
+		getEmptyTipTapDocument
+	} from '$lib/components/Paper/Editor/contentValidation';
 
 	let { data }: { data: PageData } = $props();
 
@@ -118,7 +122,10 @@
 	function openEditModal(snippet: { id: string; name: string; content: unknown }) {
 		editingId = snippet.id;
 		editName = snippet.name;
-		editContent = snippet.content as JSONContent;
+		// Validate content before using it, fallback to empty document if invalid
+		editContent = isValidTipTapContent(snippet.content)
+			? (snippet.content as JSONContent)
+			: getEmptyTipTapDocument();
 		initEditor(editContent);
 		isEditing = true;
 	}


### PR DESCRIPTION
Prevent TipTap crashes by ensuring only valid TipTap JSON is passed into editors and editor stores. Add a contentValidation helper that provides validation (isValidTipTapContent), a safe getter (getSafeTipTapContent) and an empty document factory (getEmptyTipTapDocument). Use these helpers when initializing or updating TipTap editors and when resetting review/snippet state to avoid undefined/invalid content causing runtime errors like "undefined is not an object (evaluating 'e(o).type')".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor stability with enhanced content validation that prevents crashes from invalid or corrupted content.
  * Refined editor reset behavior to ensure consistent and reliable handling of empty states.
  * Strengthened content initialization safeguards when loading previously saved content and snippets across all editor instances.
  * Better handling of edge cases in content loading workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->