### PR TITLE
Destroy tiptap editor on component unmount

### DIFF
--- a/src/lib/components/Paper/Editor/CommonEditor.svelte
+++ b/src/lib/components/Paper/Editor/CommonEditor.svelte
@@ -100,6 +100,12 @@
 			editable
 		});
 	});
+
+	onDestroy(() => {
+		if ($editor) {
+			$editor.destroy();
+		}
+	});
 </script>
 
 <fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-full border p-4 min-h-[300px]">

--- a/src/lib/components/Paper/Editor/ReviewFormat.svelte
+++ b/src/lib/components/Paper/Editor/ReviewFormat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import type { Writable } from 'svelte/store';
 	import { createEditor, Editor, EditorContent } from 'svelte-tiptap';
 	import { getCommonExtensions } from './settings/common.svelte';
@@ -166,6 +166,12 @@
 		// Only clear if store is empty object AND editor actually has content
 		if ($editor && content && Object.keys(content).length === 0 && !$editor.isEmpty) {
 			$editor.commands.clearContent();
+		}
+	});
+
+	onDestroy(() => {
+		if ($editor) {
+			$editor.destroy();
 		}
 	});
 </script>


### PR DESCRIPTION
Prevented recurring errors where the editor instance remained referenced after the component was destroyed (null is not an object evaluating 'n.docView.domFromPos'). Add onDestroy handlers to CommonEditor.svelte and ReviewFormat.svelte to call $editor.destroy() when present, and import onDestroy where needed. This ensures the tiptap editor is properly cleaned up and avoids the TypeError seen in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved editor resource cleanup on component unmount to enhance app stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->