### PR TITLE
Allow REVIEWER and PARTICIPANT_CARE to update papers

### DIFF
--- a/src/api/abilities/entities/paper/paper.ts
+++ b/src/api/abilities/entities/paper/paper.ts
@@ -23,13 +23,13 @@ export const defineAbilitiesForPaper = (oidc: OIDC, { can }: AbilityBuilder<AppA
 			}
 		});
 
-		// PROJECT_MANAGEMENT can update any paper (admin override)
+		// Team members (REVIEWER, PROJECT_MANAGEMENT, PARTICIPANT_CARE) can update any paper
 		can(['update'], 'Paper', {
 			conference: {
 				teamMembers: {
 					some: {
 						user: { id: user.sub },
-						role: 'PROJECT_MANAGEMENT'
+						role: { in: ['REVIEWER', 'PROJECT_MANAGEMENT', 'PARTICIPANT_CARE'] }
 					}
 				}
 			}


### PR DESCRIPTION
Grant additional team roles permission to update Paper records. Previously only PROJECT_MANAGEMENT could update any paper as an admin override; this change expands that to include REVIEWER and PARTICIPANT_CARE so team members with those roles can also perform updates.