### PR TITLE
Open badge generator via JS fetch instead of form submit

### DIFF
--- a/src/routes/(authenticated)/management/[conferenceId]/participants/UserDrawer.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/participants/UserDrawer.svelte
@@ -597,7 +597,15 @@
 					<button
 						class="btn"
 						onclick={async () => {
-							const body: Record = {};
+							const body: {
+								name?: string;
+								countryName?: string;
+								countryAlpha2Code?: string;
+								committee?: string;
+								pronouns?: string;
+								id?: string;
+								mediaConsentStatus?: string;
+							} = {};
 							if (user?.given_name && user?.family_name) {
 								body.name = `${user.given_name} ${user.family_name}`;
 							}
@@ -630,7 +638,25 @@
 										body: JSON.stringify(body)
 									}
 								);
-								const { url } = await res.json();
+								if (!res.ok) {
+									const errorText = await res.text();
+									console.error(`Badge generator API error (${res.status}): ${errorText}`);
+									toast.error(m.genericToastError());
+									return;
+								}
+								const data: unknown = await res.json();
+								if (
+									typeof data !== 'object' ||
+									data === null ||
+									!('url' in data) ||
+									typeof (data as { url: unknown }).url !== 'string' ||
+									(data as { url: string }).url.trim() === ''
+								) {
+									console.error('Badge generator returned invalid response:', data);
+									toast.error(m.genericToastError());
+									return;
+								}
+								const { url } = data as { url: string };
 								window.open(url.replace('http://', 'https://'), '_blank');
 							} catch (e) {
 								console.error('Failed to open badge generator', e);


### PR DESCRIPTION
Traefik in production blocked direct form submissions to the external badge generator URL. Replace the POST form with a client-side button that builds a JSON payload and calls the badge generator API via fetch, opening the returned URL in a new tab. This preserves all previously-submitted fields (name, country, committee, pronouns, id, media consent) and adds error handling and a user-visible toast on failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced badge generation with improved user experience: replaced form submission with a streamlined button-based approach that opens generated badges in a new tab and provides clearer error feedback via toast notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->