### PR TITLE
✨ chore: await mutation promises before proceeding

### DIFF
--- a/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/+page.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/paperhub/[paperId]/+page.svelte
@@ -264,18 +264,17 @@
 		const content =
 			paperData.type === 'WORKING_PAPER' ? $resolutionContentStore : $editorContentStore;
 
-		const resposne = await toast.promise(
-			updatePaperMutation.mutate({
-				paperId: paperData.id,
-				content,
-				status: newStatus
-			}),
-			{
-				loading: submit ? m.paperSubmitting() : m.paperSavingDraft(),
-				success: submit ? m.paperSubmittedSuccessfully() : m.paperDraftSavedSuccessfully(),
-				error: submit ? m.paperSubmitError() : m.paperSaveDraftError()
-			}
-		);
+		const promise = updatePaperMutation.mutate({
+			paperId: paperData.id,
+			content,
+			status: newStatus
+		});
+		toast.promise(promise, {
+			loading: submit ? m.paperSubmitting() : m.paperSavingDraft(),
+			success: submit ? m.paperSubmittedSuccessfully() : m.paperDraftSavedSuccessfully(),
+			error: submit ? m.paperSubmitError() : m.paperSaveDraftError()
+		});
+		await promise;
 
 		cache.markStale();
 		await invalidateAll();
@@ -311,16 +310,15 @@
 			return;
 		}
 
-		await toast.promise(
-			deletePaperMutation.mutate({
-				paperId: paperData.id
-			}),
-			{
-				loading: m.paperDeleting(),
-				success: m.paperDeletedSuccessfully(),
-				error: (err) => (err instanceof Error ? err.message : null) || m.paperDeleteError()
-			}
-		);
+		const promise = deletePaperMutation.mutate({
+			paperId: paperData.id
+		});
+		toast.promise(promise, {
+			loading: m.paperDeleting(),
+			success: m.paperDeletedSuccessfully(),
+			error: (err) => (err instanceof Error ? err.message : null) || m.paperDeleteError()
+		});
+		await promise;
 
 		// Navigate back to paperhub
 		const conferenceId = $page.params.conferenceId;

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Delegation/DelegationRegistrationStage.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Delegation/DelegationRegistrationStage.svelte
@@ -51,13 +51,12 @@
 			toast.error(e.result.error.message);
 		},
 		onSubmit: async () => {
-			await toast.promise(
-				updateFieldMutation.mutate({
-					where: { id: delegationMember.delegation.id },
-					...$formData
-				}),
-				genericPromiseToastMessages
-			);
+			const promise = updateFieldMutation.mutate({
+				where: { id: delegationMember.delegation.id },
+				...$formData
+			});
+			toast.promise(promise, genericPromiseToastMessages);
+			await promise;
 			// TODO this is weird. When I invalidate the cache and make him refetch here, the form resets and the data is back to the old version. Fix this!
 			cache.markStale();
 			invalidateAll();
@@ -203,10 +202,9 @@
 			return;
 		}
 		if (!confirm(m.leaveDelegationConfirmation())) return;
-		await toast.promise(
-			deleteMemberMutation.mutate({ where: { id: delegationMember.id } }),
-			genericPromiseToastMessages
-		);
+		const promise = deleteMemberMutation.mutate({ where: { id: delegationMember.id } });
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 		goto('/dashboard');
@@ -218,10 +216,11 @@
 			return;
 		}
 		if (!confirm(m.deleteDelegationConfirmation())) return;
-		await toast.promise(
-			deleteDelegationMutation.mutate({ where: { id: delegationMember.delegation.id } }),
-			genericPromiseToastMessages
-		);
+		const promise = deleteDelegationMutation.mutate({
+			where: { id: delegationMember.delegation.id }
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 		goto('/dashboard');
@@ -233,13 +232,12 @@
 			return;
 		}
 		if (!confirm(m.makeHeadDelegateConfirmation())) return;
-		await toast.promise(
-			makeHeadDelegateMutation.mutate({
-				where: { id: delegationMember.delegation.id },
-				userId
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = makeHeadDelegateMutation.mutate({
+			where: { id: delegationMember.delegation.id },
+			userId
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 	};
@@ -250,10 +248,9 @@
 			return;
 		}
 		if (!confirm(m.removeMemberConfirmation())) return;
-		await toast.promise(
-			deleteMemberMutation.mutate({ where: { id: memberId } }),
-			genericPromiseToastMessages
-		);
+		const promise = deleteMemberMutation.mutate({ where: { id: memberId } });
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 	};
@@ -264,10 +261,9 @@
 			return;
 		}
 		if (!confirm(m.completeSignupConfirmation())) return;
-		await toast.promise(
-			applyMutation.mutate({ where: { id: delegationMember.delegation.id } }),
-			genericPromiseToastMessages
-		);
+		const promise = applyMutation.mutate({ where: { id: delegationMember.delegation.id } });
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 	};
@@ -343,12 +339,11 @@
 					{referralLink}
 					userHasRotationPermission={userIsHeadDelegate}
 					rotationFn={async () => {
-						await toast.promise(
-							resetEntryCodeMutation.mutate({
-								where: { id: delegationMember.delegation.id }
-							}),
-							{ ...genericPromiseToastMessages, success: m.codeRotated() }
-						);
+						const promise = resetEntryCodeMutation.mutate({
+							where: { id: delegationMember.delegation.id }
+						});
+						toast.promise(promise, { ...genericPromiseToastMessages, success: m.codeRotated() });
+						await promise;
 						cache.markStale();
 						await invalidateAll();
 					}}

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Delegation/SelectDelegationPreferencesModal.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Delegation/SelectDelegationPreferencesModal.svelte
@@ -135,16 +135,17 @@
 	`);
 
 	const swapEntry = async (firstId: string, secondId: string) => {
-		await toast.promise(
-			swapEntryMutation.mutate({ a: firstId, b: secondId }),
-			genericPromiseToastMessages
-		);
+		const promise = swapEntryMutation.mutate({ a: firstId, b: secondId });
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 	};
 
 	const deleteEntry = async (id: string) => {
-		await toast.promise(deleteEntryMutation.mutate({ where: { id } }), genericPromiseToastMessages);
+		const promise = deleteEntryMutation.mutate({ where: { id } });
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 	};
@@ -276,13 +277,12 @@
 									cssClass="bg-base-300"
 									onClick={async () => {
 										if (!delegationMember.delegation) return;
-										await toast.promise(
-											createEntryMutation.mutate({
-												nationId: nation.alpha3Code,
-												delegationId: delegationMember.delegation.id
-											}),
-											genericPromiseToastMessages
-										);
+										const promise = createEntryMutation.mutate({
+											nationId: nation.alpha3Code,
+											delegationId: delegationMember.delegation.id
+										});
+										toast.promise(promise, genericPromiseToastMessages);
+										await promise;
 										cache.markStale();
 										await invalidateAll();
 									}}
@@ -309,13 +309,12 @@
 									cssClass="bg-base-300"
 									onClick={async () => {
 										if (!delegationMember.delegation) return;
-										await toast.promise(
-											createEntryMutation.mutate({
-												nonStateActorId: nsa.id,
-												delegationId: delegationMember.delegation.id
-											}),
-											genericPromiseToastMessages
-										);
+										const promise = createEntryMutation.mutate({
+											nonStateActorId: nsa.id,
+											delegationId: delegationMember.delegation.id
+										});
+										toast.promise(promise, genericPromiseToastMessages);
+										await promise;
 										cache.markStale();
 										await invalidateAll();
 									}}

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipant/SingleParticipantRegistrationStage.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/SingleParticipant/SingleParticipantRegistrationStage.svelte
@@ -36,13 +36,12 @@
 			toast.error(e.result.error.message);
 		},
 		onSubmit: async () => {
-			await toast.promise(
-				updateMutation.mutate({
-					where: { id: singleParticipant.id },
-					...$formData
-				}),
-				genericPromiseToastMessages
-			);
+			const promise = updateMutation.mutate({
+				where: { id: singleParticipant.id },
+				...$formData
+			});
+			toast.promise(promise, genericPromiseToastMessages);
+			await promise;
 			cache.markStale();
 			await invalidateAll();
 		}
@@ -91,13 +90,12 @@
 			return;
 		}
 		if (!confirm(m.completeSignupConfirmation())) return;
-		await toast.promise(
-			updateMutation.mutate({
-				where: { id: singleParticipant.id },
-				applied: true
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = updateMutation.mutate({
+			where: { id: singleParticipant.id },
+			applied: true
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 	};
@@ -109,12 +107,11 @@
 		}
 		if (!confirm(m.deleteAllApplicationsConfirmation())) return;
 
-		await toast.promise(
-			deleteMutation.mutate({
-				where: { id: singleParticipant.id }
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = deleteMutation.mutate({
+			where: { id: singleParticipant.id }
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 		goto('/dashboard');
@@ -126,13 +123,12 @@
 			return;
 		}
 		if (!confirm(m.deleteApplicationConfirmation())) return;
-		await toast.promise(
-			updateMutation.mutate({
-				where: { id: singleParticipant.id },
-				unApplyForRolesIdList: [id]
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = updateMutation.mutate({
+			where: { id: singleParticipant.id },
+			unApplyForRolesIdList: [id]
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 		goto('/dashboard');

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Supervisor/Supervisor.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/stages/Supervisor/Supervisor.svelte
@@ -163,24 +163,23 @@
 	`);
 
 	const handlePresenceChange = async (e: Event) => {
-		await toast.promise(
-			updateQuery.mutate({
-				where: {
-					conferenceId_userId: {
-						conferenceId: conference.id,
-						userId: user.sub
-					}
-				},
-				data: {
-					plansOwnAttendenceAtConference: (e.target as HTMLInputElement).checked
+		const promise = updateQuery.mutate({
+			where: {
+				conferenceId_userId: {
+					conferenceId: conference.id,
+					userId: user.sub
 				}
-			}),
-			{
-				loading: m.genericToastLoading(),
-				success: m.genericToastSuccess(),
-				error: m.genericToastError()
+			},
+			data: {
+				plansOwnAttendenceAtConference: (e.target as HTMLInputElement).checked
 			}
-		);
+		});
+		toast.promise(promise, {
+			loading: m.genericToastLoading(),
+			success: m.genericToastSuccess(),
+			error: m.genericToastError()
+		});
+		await promise;
 
 		cache.markStale();
 		await invalidateAll();
@@ -651,16 +650,15 @@
 		referralLink={connectionLink}
 		userHasRotationPermission={true}
 		rotationFn={async () => {
-			await toast.promise(
-				rotateConnectionCodeMutation.mutate({
-					id: supervisor.id
-				}),
-				{
-					loading: m.genericToastLoading(),
-					success: m.codeRotated(),
-					error: m.genericToastError()
-				}
-			);
+			const promise = rotateConnectionCodeMutation.mutate({
+				id: supervisor.id
+			});
+			toast.promise(promise, {
+				loading: m.genericToastLoading(),
+				success: m.codeRotated(),
+				error: m.genericToastError()
+			});
+			await promise;
 			cache.markStale();
 			await invalidateAll();
 		}}

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/committees/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/committees/+page.svelte
@@ -95,39 +95,36 @@
 	`);
 
 	async function saveCommittee() {
-		await toast.promise(
-			UpdateCommitteeMutation.mutate({
-				id: editingCommittee.id,
-				name: editingCommittee.name,
-				abbreviation: editingCommittee.abbreviation,
-				resolutionHeadline: editingCommittee.resolutionHeadline
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = UpdateCommitteeMutation.mutate({
+			id: editingCommittee.id,
+			name: editingCommittee.name,
+			abbreviation: editingCommittee.abbreviation,
+			resolutionHeadline: editingCommittee.resolutionHeadline
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		editCommitteeModalOpen = false;
 		cache.markStale();
 		invalidateAll();
 	}
 
 	async function saveAgendaItem() {
-		await toast.promise(
-			UpdateAgendaItemMutation.mutate({
-				id: editingAgendaItem.id,
-				title: editingAgendaItem.title,
-				teaserText: editingAgendaItem.teaserText
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = UpdateAgendaItemMutation.mutate({
+			id: editingAgendaItem.id,
+			title: editingAgendaItem.title,
+			teaserText: editingAgendaItem.teaserText
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		editAgendaItemModalOpen = false;
 		cache.markStale();
 		invalidateAll();
 	}
 
 	async function confirmDelete() {
-		await toast.promise(
-			DeleteAgendaItemMutation.mutate({ id: deleteConfirmation.id }),
-			genericPromiseToastMessages
-		);
+		const promise = DeleteAgendaItemMutation.mutate({ id: deleteConfirmation.id });
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		deleteModalOpen = false;
 		cache.markStale();
 		invalidateAll();

--- a/src/routes/(authenticated)/management/[conferenceId]/delegations/CommitteeAssignmentModal.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/delegations/CommitteeAssignmentModal.svelte
@@ -81,12 +81,11 @@
 			if (!members) return;
 			loading = true;
 			try {
-				await toast.promise(
-					resetCommitteeAssignmentForAllDelegationMembers.mutate({
-						delegationMemberIds: members.map((m) => m.id)
-					}),
-					genericPromiseToastMessages
-				);
+				const promise = resetCommitteeAssignmentForAllDelegationMembers.mutate({
+					delegationMemberIds: members.map((m) => m.id)
+				});
+				toast.promise(promise, genericPromiseToastMessages);
+				await promise;
 
 				cache.markStale();
 				await invalidateAll();
@@ -138,13 +137,12 @@
 									onclick={async () => {
 										loading = true;
 										try {
-											await toast.promise(
-												updateDelegationMemberAssignedCommittee.mutate({
-													committeeId: committee.id,
-													delegationMemberId: member.id
-												}),
-												genericPromiseToastMessages
-											);
+											const promise = updateDelegationMemberAssignedCommittee.mutate({
+												committeeId: committee.id,
+												delegationMemberId: member.id
+											});
+											toast.promise(promise, genericPromiseToastMessages);
+											await promise;
 
 											cache.markStale();
 											await invalidateAll();

--- a/src/routes/(authenticated)/management/[conferenceId]/delegations/DelegationDrawer.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/delegations/DelegationDrawer.svelte
@@ -160,13 +160,12 @@
 		if (!newSchool) return;
 
 		try {
-			await toast.promise(
-				changeDelegationSchoolMutation.mutate({
-					delegationId,
-					newSchool
-				}),
-				genericPromiseToastMessages
-			);
+			const promise = changeDelegationSchoolMutation.mutate({
+				delegationId,
+				newSchool
+			});
+			toast.promise(promise, genericPromiseToastMessages);
+			await promise;
 			cache.markStale();
 			await invalidateAll();
 		} catch (error) {
@@ -405,13 +404,12 @@
 			class="btn {!delegation?.applied && 'btn-disabled'} btn-error"
 			onclick={async () => {
 				if (!confirm(m.confirmRevokeApplication())) return;
-				await toast.promise(
-					delegaitonResetMutation.mutate({
-						delegationId,
-						applied: false
-					}),
-					genericPromiseToastMessages
-				);
+				const promise = delegaitonResetMutation.mutate({
+					delegationId,
+					applied: false
+				});
+				toast.promise(promise, genericPromiseToastMessages);
+				await promise;
 				cache.markStale();
 				await invalidateAll();
 			}}

--- a/src/routes/(authenticated)/management/[conferenceId]/individuals/IndividualDrawer.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/individuals/IndividualDrawer.svelte
@@ -219,13 +219,12 @@
 				'btn-disabled'} btn-error"
 			onclick={async () => {
 				if (!confirm(m.confirmRevokeApplication())) return;
-				await toast.promise(
-					singleParticipantResetMutation.mutate({
-						singleParticipantId: $singleParticipantQuery!.data!.findUniqueSingleParticipant!.id!,
-						applied: false
-					}),
-					genericPromiseToastMessages
-				);
+				const promise = singleParticipantResetMutation.mutate({
+					singleParticipantId: $singleParticipantQuery!.data!.findUniqueSingleParticipant!.id!,
+					applied: false
+				});
+				toast.promise(promise, genericPromiseToastMessages);
+				await promise;
 				cache.markStale();
 				await invalidateAll();
 			}}

--- a/src/routes/(authenticated)/management/[conferenceId]/participants/GlobalNotes.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/participants/GlobalNotes.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { graphql } from '$houdini';
+	import { cache, graphql } from '$houdini';
+	import { invalidateAll } from '$app/navigation';
 	import Modal from '$lib/components/Modal.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { toast } from 'svelte-sonner';
@@ -25,19 +26,20 @@
 
 	const saveGlobalNotes = async () => {
 		if (!id) return;
-		await toast.promise(
-			saveGlobalNotesMutation.mutate({
-				where: {
-					id
-				},
-				globalNotes: value
-			}),
-			{
-				success: m.saved(),
-				error: m.httpGenericError(),
-				loading: m.saving()
-			}
-		);
+		const promise = saveGlobalNotesMutation.mutate({
+			where: {
+				id
+			},
+			globalNotes: value
+		});
+		toast.promise(promise, {
+			success: m.saved(),
+			error: m.httpGenericError(),
+			loading: m.saving()
+		});
+		await promise;
+		cache.markStale();
+		await invalidateAll();
 
 		open = false;
 	};

--- a/src/routes/(authenticated)/management/[conferenceId]/participants/ImpersonationButton.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/participants/ImpersonationButton.svelte
@@ -22,10 +22,9 @@
 		if (isLoading) return;
 		isLoading = true;
 		try {
-			await toast.promise(
-				StartImpersonationMutation.mutate({ targetUserId: userId }),
-				genericPromiseToastMessages
-			);
+			const promise = StartImpersonationMutation.mutate({ targetUserId: userId });
+			toast.promise(promise, genericPromiseToastMessages);
+			await promise;
 			await goto('/dashboard');
 			window.location.reload();
 		} catch (error) {

--- a/src/routes/(authenticated)/management/[conferenceId]/postalRegistration/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/postalRegistration/+page.svelte
@@ -214,13 +214,12 @@
 			toast.error(m.userNotFound());
 			return;
 		}
-		await toast.promise(
-			changeParticipantStatus.mutate({
-				where: { id: statusId, conferenceId: data.conferenceId, userId },
-				data: mutationData
-			}),
-			genericPromiseToastMessages
-		);
+		const promise = changeParticipantStatus.mutate({
+			where: { id: statusId, conferenceId: data.conferenceId, userId },
+			data: mutationData
+		});
+		toast.promise(promise, genericPromiseToastMessages);
+		await promise;
 		cache.markStale();
 		userData.fetch();
 	};

--- a/src/routes/(authenticated)/management/[conferenceId]/team/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/team/+page.svelte
@@ -34,11 +34,13 @@
 	const handleDelete = async (id: string) => {
 		if (!confirm(m.confirmDeleteTeamMember())) return;
 
-		await toast.promise(deleteTeamMemberMutation.mutate({ id }), {
+		const promise = deleteTeamMemberMutation.mutate({ id });
+		toast.promise(promise, {
 			loading: m.deletingTeamMember(),
 			success: m.teamMemberDeleted(),
 			error: m.deleteTeamMemberError()
 		});
+		await promise;
 
 		cache.markStale();
 		await invalidateAll();
@@ -46,10 +48,9 @@
 
 	const handleImpersonate = async (userId: string) => {
 		try {
-			await toast.promise(
-				startImpersonationMutation.mutate({ targetUserId: userId }),
-				genericPromiseToastMessages
-			);
+			const promise = startImpersonationMutation.mutate({ targetUserId: userId });
+			toast.promise(promise, genericPromiseToastMessages);
+			await promise;
 			await goto('/dashboard');
 			window.location.reload();
 		} catch (error) {

--- a/src/routes/(authenticated)/management/[conferenceId]/team/AddTeamMemberModal.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/team/AddTeamMemberModal.svelte
@@ -74,18 +74,17 @@
 			return;
 		}
 
-		await toast.promise(
-			createTeamMemberMutation.mutate({
-				conferenceId,
-				userId: foundUser.id,
-				role: selectedRole as any
-			}),
-			{
-				loading: m.addingTeamMember(),
-				success: m.teamMemberAdded(),
-				error: (err) => (err instanceof Error ? err.message : null) || m.addTeamMemberError()
-			}
-		);
+		const promise = createTeamMemberMutation.mutate({
+			conferenceId,
+			userId: foundUser.id,
+			role: selectedRole as any
+		});
+		toast.promise(promise, {
+			loading: m.addingTeamMember(),
+			success: m.teamMemberAdded(),
+			error: (err) => (err instanceof Error ? err.message : null) || m.addTeamMemberError()
+		});
+		await promise;
 		cache.markStale();
 		await invalidateAll();
 		open = false;

--- a/src/routes/(authenticated)/management/[conferenceId]/waitingList/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/waitingList/+page.svelte
@@ -185,13 +185,12 @@
 				<button
 					class="btn btn-outline"
 					onclick={async () => {
-						await toast.promise(
-							updateWaitingListEntryMutation.mutate({
-								id: row.id,
-								hidden: !row.hidden
-							}),
-							genericPromiseToastMessages
-						);
+						const promise = updateWaitingListEntryMutation.mutate({
+							id: row.id,
+							hidden: !row.hidden
+						});
+						toast.promise(promise, genericPromiseToastMessages);
+						await promise;
 						cache.markStale();
 						await invalidateAll();
 					}}
@@ -206,10 +205,9 @@
 					class="btn btn-outline btn-error"
 					onclick={async () => {
 						if (!confirm(m.areYouSure())) return;
-						await toast.promise(
-							deleteWaitingListEntryMutation.mutate({ id: row.id }),
-							genericPromiseToastMessages
-						);
+						const promise = deleteWaitingListEntryMutation.mutate({ id: row.id });
+						toast.promise(promise, genericPromiseToastMessages);
+						await promise;
 
 						cache.markStale();
 						await invalidateAll();


### PR DESCRIPTION
Refactor UI mutations to capture the returned mutation promise, pass it
into toast.promise for user feedback, then await the promise before
continuing. This replaces directly awaiting toast.promise(mutator(...))
with a two-step pattern: call mutation -> toast.promise(promise, ...)
-> await promise.

Most important changes:
- Ensure code awaits the actual mutation result to avoid race conditions
  with subsequent cache.markStale, invalidateAll, navigation, and UI
  state updates.
- Standardize promise handling across multiple components:
  GlobalNotes, CommitteeAssignmentModal, paper hub page, SelectDelegation
  Preferences modal, and related handlers.
- Preserve existing toast messages and loading/success/error text while
  making behavior more reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized promise handling across many actions to improve reliability and consistency while preserving all user-facing behavior — toast notifications, loading/success/error messages, navigation, and state updates remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->