### PR TITLE
Fix the logic of pieces unlock for NSAs

### DIFF
--- a/src/api/resolvers/modules/paper/paperReview.ts
+++ b/src/api/resolvers/modules/paper/paperReview.ts
@@ -236,6 +236,7 @@ builder.mutationFields((t) => ({
 							where: {
 								delegationId: paper.delegationId,
 								conferenceId: paper.conferenceId,
+								type: { not: 'INTRODUCTION_PAPER' },
 								status: { not: 'DRAFT' },
 								versions: {
 									some: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paper review logic now treats introduction papers separately from regular papers when determining first-review status and unlock eligibility.
* **New Features**
  * Piece unlocks are driven per paper type; when a piece is first unlocked the system records and returns unlock details.
  * Notifications and unlock indicators now reflect the per-type first-review detection and counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->