### PR TITLE
feat (Frontend): Add conference logo field for dashboard header

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -276,6 +276,8 @@
 	"conferenceInfoDescription": "Bleib über alles konferenzrelevante auf dem Laufenden, indem du dir die aktuellen Konferenzinformationen durchliest und schaue immer mal wieder nach, ob neue Inhalte hinzugefügt wurden.",
 	"conferenceLanguage": "Konferenzsprache",
 	"conferenceLocation": "Ort",
+	"conferenceLogo": "Konferenz-Logo",
+	"conferenceLogoHint": "Bilddatei für das Logo im Dashboard-Header. Falls nicht gesetzt, wird das Emblem als Fallback verwendet.",
 	"conferenceLongTitle": "Voller Name",
 	"conferencePapers": "Konferenz-Papiere",
 	"conferenceSeats": "Plätze der Konferenz",

--- a/messages/en.json
+++ b/messages/en.json
@@ -276,6 +276,8 @@
 	"conferenceInfoDescription": "Lies dir die aktuellen Konferenzinformationen aufmerksam durch und schaue immer mal wieder nach, ob es Neuigkeiten gibt.",
 	"conferenceLanguage": "Conference Language",
 	"conferenceLocation": "Location",
+	"conferenceLogo": "Conference Logo",
+	"conferenceLogoHint": "Image file for the logo displayed in the dashboard header. If not set, the emblem will be used as fallback.",
 	"conferenceLongTitle": "Full Name",
 	"conferencePapers": "Conference Papers",
 	"conferenceSeats": "Seats of the Conference",

--- a/prisma/migrations/20260122231324_add_conference_logo/migration.sql
+++ b/prisma/migrations/20260122231324_add_conference_logo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Conference" ADD COLUMN     "logoDataURL" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model Conference {
   imageDataURL                           String?
   /// SVG data URL for conference emblem (falls back to UN emblem if null)
   emblemDataURL                          String?
+  /// Data URL for conference logo (displayed in dashboard header)
+  logoDataURL                            String?
   info                                   String?
   /// When true, dashboard announcement shows full content; when false, truncated with expand button
   showInfoExpanded                       Boolean         @default(false)

--- a/schema.graphql
+++ b/schema.graphql
@@ -358,6 +358,9 @@ type Conference {
   linkToServicesPage: String
   linkToTeamWiki: String
   location: String
+
+  """Data URL for conference logo (displayed in dashboard header)"""
+  logoDataURL: String
   longTitle: String
   mediaConsentContent: String
   mediaConsentContentSet: Boolean!
@@ -426,6 +429,7 @@ input ConferenceCreateInput {
   linkToServicesPage: String
   linkToTeamWiki: String
   location: String
+  logoDataURL: String
   longTitle: String
   mediaConsentContent: String
   nonStateActors: NonStateActorCreateNestedManyWithoutConferenceInput
@@ -483,6 +487,7 @@ input ConferenceOrderByWithRelationInput {
   linkToServicesPage: SortOrder
   linkToTeamWiki: SortOrder
   location: SortOrder
+  logoDataURL: SortOrder
   longTitle: SortOrder
   mediaConsentContent: SortOrder
   nonStateActors: NonStateActorOrderByRelationAggregateInput
@@ -710,6 +715,7 @@ enum ConferenceScalarFieldEnum {
   linkToServicesPage
   linkToTeamWiki
   location
+  logoDataURL
   longTitle
   mediaConsentContent
   postalApartment
@@ -943,6 +949,7 @@ input ConferenceUpdateDataInput {
   linkToServicesPage: String
   linkToTeamWiki: String
   location: String
+  logo: File
   longTitle: String
   mediaConsentBasePDF: File
   postalApartment: String
@@ -993,6 +1000,7 @@ input ConferenceUpdateInput {
   linkToServicesPage: NullableStringFieldUpdateOperationsInput
   linkToTeamWiki: NullableStringFieldUpdateOperationsInput
   location: NullableStringFieldUpdateOperationsInput
+  logoDataURL: NullableStringFieldUpdateOperationsInput
   longTitle: NullableStringFieldUpdateOperationsInput
   mediaConsentContent: NullableStringFieldUpdateOperationsInput
   nonStateActors: NonStateActorUpdateManyWithoutConferenceNestedInput
@@ -1043,6 +1051,7 @@ input ConferenceUpdateManyMutationInput {
   linkToServicesPage: NullableStringFieldUpdateOperationsInput
   linkToTeamWiki: NullableStringFieldUpdateOperationsInput
   location: NullableStringFieldUpdateOperationsInput
+  logoDataURL: NullableStringFieldUpdateOperationsInput
   longTitle: NullableStringFieldUpdateOperationsInput
   mediaConsentContent: NullableStringFieldUpdateOperationsInput
   postalApartment: NullableStringFieldUpdateOperationsInput
@@ -1097,6 +1106,7 @@ input ConferenceWhereInput {
   linkToServicesPage: StringNullableFilter
   linkToTeamWiki: StringNullableFilter
   location: StringNullableFilter
+  logoDataURL: StringNullableFilter
   longTitle: StringNullableFilter
   mediaConsentContent: StringNullableFilter
   nonStateActors: NonStateActorListRelationFilter
@@ -1157,6 +1167,7 @@ input ConferenceWhereUniqueInput {
   linkToServicesPage: StringNullableFilter
   linkToTeamWiki: StringNullableFilter
   location: StringNullableFilter
+  logoDataURL: StringNullableFilter
   longTitle: StringNullableFilter
   mediaConsentContent: StringNullableFilter
   nonStateActors: NonStateActorListRelationFilter

--- a/src/api/resolvers/modules/conference/conference.ts
+++ b/src/api/resolvers/modules/conference/conference.ts
@@ -11,6 +11,7 @@ import {
 	ConferenceIdFieldObject,
 	ConferenceImageDataURLFieldObject,
 	ConferenceEmblemDataURLFieldObject,
+	ConferenceLogoDataURLFieldObject,
 	ConferenceInfoFieldObject,
 	ConferenceLanguageFieldObject,
 	ConferenceLinkToPaperInboxFieldObject,
@@ -67,6 +68,7 @@ builder.prismaObject('Conference', {
 		website: t.field(ConferenceWebsiteFieldObject),
 		imageDataURL: t.field(ConferenceImageDataURLFieldObject),
 		emblemDataURL: t.field(ConferenceEmblemDataURLFieldObject),
+		logoDataURL: t.field(ConferenceLogoDataURLFieldObject),
 		state: t.field(ConferenceStateFieldObject),
 		startAssignment: t.field(ConferenceStartAssignmentFieldObject),
 		registrationDeadlineGracePeriodMinutes: t.field(
@@ -495,6 +497,10 @@ builder.mutationFields((t) => {
 								type: 'File',
 								required: false
 							}),
+							logo: t.field({
+								type: 'File',
+								required: false
+							}),
 							state: t.field({ type: ConferenceState, required: false }),
 							startAssignment: t.field({ type: 'DateTime', required: false }),
 							registrationDeadlineGracePeriodMinutes: t.int({ required: false }),
@@ -582,6 +588,9 @@ builder.mutationFields((t) => {
 					: args.data.emblem;
 				args.data.emblem = undefined;
 
+				const logoDataURL = args.data.logo ? await toDataURL(args.data.logo) : args.data.logo;
+				args.data.logo = undefined;
+
 				const contractContentURL = args.data.contractBasePDF
 					? await toDataURL(args.data.contractBasePDF)
 					: args.data.contractBasePDF;
@@ -613,6 +622,7 @@ builder.mutationFields((t) => {
 						...args.data,
 						imageDataURL: dataURL,
 						emblemDataURL: emblemDataURL,
+						logoDataURL: logoDataURL,
 						title: args.data.title ?? undefined,
 						info: args.data.info ?? undefined,
 						state: args.data.state ?? undefined,

--- a/src/lib/components/Dashboard/ConferenceHeader.svelte
+++ b/src/lib/components/Dashboard/ConferenceHeader.svelte
@@ -9,9 +9,10 @@
 		startDate?: Date | null;
 		endDate?: Date | null;
 		emblemDataURL?: string | null;
+		logoDataURL?: string | null;
 	}
 
-	let { title, longTitle, state, startDate, endDate, emblemDataURL }: Props = $props();
+	let { title, longTitle, state, startDate, endDate, emblemDataURL, logoDataURL }: Props = $props();
 
 	const formatDate = (date: Date | null | undefined) => {
 		if (!date) return '';
@@ -78,7 +79,15 @@
 <header class="card bg-base-100 border-base-200 border shadow-sm">
 	<div class="card-body">
 		<div class="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
-			{#if emblemDataURL}
+			{#if logoDataURL}
+				<div class="shrink-0">
+					<img
+						src={logoDataURL}
+						alt={title}
+						class="h-20 w-20 rounded-lg object-contain md:h-24 md:w-24"
+					/>
+				</div>
+			{:else if emblemDataURL}
 				<div class="shrink-0">
 					<img
 						src={emblemDataURL}

--- a/src/lib/queries/myConferenceparticipationQuery.ts
+++ b/src/lib/queries/myConferenceparticipationQuery.ts
@@ -39,6 +39,7 @@ export const myConferenceparticipationQuery = graphql(`
 			postalCity
 			postalCountry
 			emblemDataURL
+			logoDataURL
 			committees {
 				id
 				abbreviation

--- a/src/routes/(authenticated)/dashboard/[conferenceId]/+page.svelte
+++ b/src/routes/(authenticated)/dashboard/[conferenceId]/+page.svelte
@@ -41,6 +41,7 @@
 				startDate={conference.startConference}
 				endDate={conference.endConference}
 				emblemDataURL={conference.emblemDataURL}
+				logoDataURL={conference.logoDataURL}
 			/>
 			{#if conference.info && !teamMember}
 				<DashboardSection

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.server.ts
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.server.ts
@@ -23,6 +23,7 @@ const conferenceQuery = graphql(`
 			endConference
 			imageDataURL
 			emblemDataURL
+			logoDataURL
 			language
 			linkToPreparationGuide
 			linkToTeamWiki
@@ -140,6 +141,7 @@ export const load: PageServerLoad = async (event) => {
 		committeesData: committeesResult.data?.findManyCommittees ?? [],
 		imageDataURL: conference.imageDataURL,
 		emblemDataURL: conference.emblemDataURL,
+		logoDataURL: conference.logoDataURL,
 		certificateContentSet: conference.certificateContentSet,
 		termsAndConditionsContentSet: conference.termsAndConditionsContentSet,
 		mediaConsentContentSet: conference.mediaConsentContentSet,

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/+page.svelte
@@ -538,6 +538,18 @@
 					<FormFileInput {form} name="emblem" label={m.conferenceEmblem()} accept="image/svg+xml" />
 					<p class="text-xs opacity-50 mt-1">{m.conferenceEmblemHint()}</p>
 				</div>
+				<div class="mt-4">
+					<p class="text-sm opacity-70 mb-2">{m.conferenceLogo()}</p>
+					{#if $formData.logo || data.logoDataURL}
+						<img
+							src={$formData.logo ? URL.createObjectURL($formData.logo) : data.logoDataURL}
+							class="h-24 w-24 mb-2"
+							alt="Logo preview"
+						/>
+					{/if}
+					<FormFileInput {form} name="logo" label={m.conferenceLogo()} accept="image/*" />
+					<p class="text-xs opacity-50 mt-1">{m.conferenceLogoHint()}</p>
+				</div>
 				<FormDateTimeInput
 					{form}
 					name="startAssignment"

--- a/src/routes/(authenticated)/management/[conferenceId]/configuration/form-schema.ts
+++ b/src/routes/(authenticated)/management/[conferenceId]/configuration/form-schema.ts
@@ -45,6 +45,10 @@ export const conferenceSettingsFormSchema = z.object({
 		.instanceof(File)
 		.refine((f) => f.size < 1_000_000, 'Max 1mb upload size.')
 		.optional(),
+	logo: z
+		.instanceof(File)
+		.refine((f) => f.size < 1_000_000, 'Max 1mb upload size.')
+		.optional(),
 	startAssignment: z.date({
 		message: m.pleaseEnterAValidDate()
 	}),


### PR DESCRIPTION
## Summary

- Add a new `logoDataURL` field to the Conference model that displays in the dashboard header
- Logo takes priority over emblem, with emblem as fallback, then a landmark icon
- Logo accepts any image type (unlike emblem which only accepts SVG)
- Upload preview shows the selected file before saving

## Changes

- Add `logoDataURL` field to Prisma schema with migration
- Add logo field to GraphQL resolver and mutation
- Add logo upload section with preview on configuration page
- Update ConferenceHeader component to prioritize logo over emblem
- Add German and English translations

## Test plan

- [x] Navigate to conference configuration page
- [x] Upload a logo image (PNG, JPG, etc.)
- [x] Verify preview shows correctly before saving
- [x] Save configuration
- [x] Navigate to dashboard
- [x] Verify logo displays in header
- [x] Test fallback: remove logo, verify emblem shows; remove emblem, verify icon shows

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added conference logo upload and display functionality with a max file size of 1 MB
* Logo appears in the dashboard header, with automatic fallback to the existing emblem
* Localized labels added for logo configuration in conference settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->