### PR TITLE
fix(calendar): Replace @prisma/client imports with $houdini in browser code

### DIFF
--- a/src/lib/components/Calendar/CalendarDayView.svelte
+++ b/src/lib/components/Calendar/CalendarDayView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { CalendarEntryColor } from '@prisma/client';
+	import type { CalendarEntryColor$options } from '$houdini';
 	import CalendarEntryCard from './CalendarEntryCard.svelte';
 	import CalendarTimeMarker from './CalendarTimeMarker.svelte';
 
@@ -17,7 +17,7 @@
 		name: string;
 		description?: string | null;
 		fontAwesomeIcon?: string | null;
-		color: CalendarEntryColor;
+		color: CalendarEntryColor$options;
 		place?: {
 			id: string;
 			name: string;

--- a/src/lib/components/Calendar/CalendarDisplay.svelte
+++ b/src/lib/components/Calendar/CalendarDisplay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { CalendarEntryColor } from '@prisma/client';
+	import type { CalendarEntryColor$options } from '$houdini';
 	import CalendarDayView from './CalendarDayView.svelte';
 	import CalendarEntryDrawer from './CalendarEntryDrawer.svelte';
 	import { m } from '$lib/paraglide/messages';
@@ -18,7 +18,7 @@
 		name: string;
 		description?: string | null;
 		fontAwesomeIcon?: string | null;
-		color: CalendarEntryColor;
+		color: CalendarEntryColor$options;
 		place?: {
 			id: string;
 			name: string;

--- a/src/lib/components/Calendar/CalendarEntryCard.svelte
+++ b/src/lib/components/Calendar/CalendarEntryCard.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import type { CalendarEntryColor } from '@prisma/client';
+	import type { CalendarEntryColor$options } from '$houdini';
 	import { getColorConfig } from './calendarColors';
 
 	interface Props {
 		name: string;
 		description?: string | null;
 		fontAwesomeIcon?: string | null;
-		color: CalendarEntryColor;
+		color: CalendarEntryColor$options;
 		startTime: Date;
 		endTime: Date;
 		place?: { name: string } | null;

--- a/src/lib/components/Calendar/CalendarEntryDrawer.svelte
+++ b/src/lib/components/Calendar/CalendarEntryDrawer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Drawer } from 'vaul-svelte';
 	import type { DrawerDirection } from 'vaul-svelte';
-	import type { CalendarEntryColor } from '@prisma/client';
+	import type { CalendarEntryColor$options } from '$houdini';
 	import { browser } from '$app/environment';
 	import { getColorConfig } from './calendarColors';
 	import { translateCalendarEntryColor } from '$lib/services/enumTranslations';
@@ -26,7 +26,7 @@
 		name: string;
 		description?: string | null;
 		fontAwesomeIcon?: string | null;
-		color: CalendarEntryColor;
+		color: CalendarEntryColor$options;
 		place?: Place | null;
 		room?: string | null;
 		calendarTrackId?: string | null;

--- a/src/lib/components/Calendar/ColorPaletteSelector.svelte
+++ b/src/lib/components/Calendar/ColorPaletteSelector.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-	import type { CalendarEntryColor } from '@prisma/client';
+	import type { CalendarEntryColor$options } from '$houdini';
 	import { allColors, getColorConfig } from './calendarColors';
 	import { m } from '$lib/paraglide/messages';
 
 	interface Props {
-		value: CalendarEntryColor;
-		onchange: (color: CalendarEntryColor) => void;
+		value: CalendarEntryColor$options;
+		onchange: (color: CalendarEntryColor$options) => void;
 	}
 
 	let { value, onchange }: Props = $props();
 
-	const colorLabels: Record<CalendarEntryColor, () => string> = {
+	const colorLabels: Record<CalendarEntryColor$options, () => string> = {
 		SESSION: () => m.calendarSession(),
 		WORKSHOP: () => m.calendarWorkshop(),
 		LOGISTICS: () => m.calendarLogistics(),

--- a/src/lib/components/Calendar/calendarColors.ts
+++ b/src/lib/components/Calendar/calendarColors.ts
@@ -1,4 +1,4 @@
-import type { CalendarEntryColor } from '@prisma/client';
+import { CalendarEntryColor, type CalendarEntryColor$options } from '$houdini';
 
 interface ColorConfig {
 	bg: string;
@@ -7,7 +7,7 @@ interface ColorConfig {
 	ring: string;
 }
 
-const colorMap: Record<CalendarEntryColor, ColorConfig> = {
+const colorMap: Record<CalendarEntryColor$options, ColorConfig> = {
 	SESSION: {
 		bg: 'bg-primary/15',
 		border: 'border-primary',
@@ -58,8 +58,8 @@ const colorMap: Record<CalendarEntryColor, ColorConfig> = {
 	}
 };
 
-export function getColorConfig(color: CalendarEntryColor): ColorConfig {
+export function getColorConfig(color: CalendarEntryColor$options): ColorConfig {
 	return colorMap[color];
 }
 
-export const allColors = Object.keys(colorMap) as CalendarEntryColor[];
+export const allColors = Object.keys(colorMap) as CalendarEntryColor$options[];

--- a/src/lib/schemata/calendarDayExport.ts
+++ b/src/lib/schemata/calendarDayExport.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CalendarEntryColor } from '@prisma/client';
+import { CalendarEntryColor } from '$houdini';
 
 const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
 

--- a/src/routes/(authenticated)/management/[conferenceId]/calendar/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/calendar/+page.svelte
@@ -5,7 +5,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import CalendarDisplay from '$lib/components/Calendar/CalendarDisplay.svelte';
 	import ColorPaletteSelector from '$lib/components/Calendar/ColorPaletteSelector.svelte';
-	import type { CalendarEntryColor } from '@prisma/client';
+	import type { CalendarEntryColor$options } from '$houdini';
 	import { translateCalendarEntryColor } from '$lib/services/enumTranslations';
 	import { downloadJSON } from '$lib/services/downloadHelpers';
 	import {
@@ -599,7 +599,7 @@
 	let entryStartTime = $state('');
 	let entryEndTime = $state('');
 	let entryIcon = $state('');
-	let entryColor = $state<CalendarEntryColor>('SESSION');
+	let entryColor = $state<CalendarEntryColor$options>('SESSION');
 	let entryPlaceId = $state<string | null>(null);
 	let entryRoom = $state('');
 	let entryTrackId = $state<string | null>(null);


### PR DESCRIPTION
## Summary
- Calendar components imported `CalendarEntryColor` from `@prisma/client`, which is a server-only package
- Production builds fail with a bare specifier resolution error (`.prisma/client/index-browser`), while dev works because Vite handles the module resolution differently
- Replaced all 8 occurrences with Houdini-generated equivalents: `CalendarEntryColor$options` (type) and `CalendarEntryColor` (runtime value) from `$houdini`

## Test plan
- [x] `bun run check` passes with 0 errors
- [ ] Verify calendar page loads in production build without the specifier error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated calendar color type definitions across components for improved internal consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->