### PR TITLE
fix (Backend): Reduce noisy OIDC token validation logs

### DIFF
--- a/src/api/context/oidc.ts
+++ b/src/api/context/oidc.ts
@@ -65,7 +65,9 @@ export async function oidc(cookies: RequestEvent['cookies']) {
 			id_token: tokenSet.id_token
 		});
 	} catch (error) {
-		console.warn(`Failed to retrieve user info from tokens`, error);
+		console.debug(
+			`[OIDC] Token validation failed (${error instanceof Error ? error.message : 'unknown'}), attempting refresh`
+		);
 	}
 
 	if (!user) {
@@ -99,11 +101,15 @@ export async function oidc(cookies: RequestEvent['cookies']) {
 					id_token: refreshed.id_token
 				});
 			} catch (e) {
-				console.warn('Refreshed tokens failed validation', e);
+				console.warn(
+					`[OIDC] Refreshed tokens failed validation: ${e instanceof Error ? e.message : e}`
+				);
 				return { nextTokenRefreshDue: undefined, tokenSet: undefined, user: undefined };
 			}
 		} catch (error) {
-			console.warn(`Failed to refresh tokens`, error);
+			console.warn(
+				`[OIDC] Token refresh failed: ${error instanceof Error ? error.message : error}`
+			);
 			return { nextTokenRefreshDue: undefined, tokenSet: undefined, user: undefined };
 		}
 	}

--- a/src/api/services/OIDC.ts
+++ b/src/api/services/OIDC.ts
@@ -174,9 +174,8 @@ export async function validateTokens({
 
 		return idTokenValue.payload;
 	} catch (error: any) {
-		console.warn(
-			'Failed to verify tokens locally, falling back to less performant info fetch:',
-			error.message
+		console.debug(
+			`[OIDC] Local token verification failed (${error.message}), trying remote introspection`
 		);
 
 		const remoteUserInfo = await tokenIntrospection(config, access_token);


### PR DESCRIPTION
## Summary
- Downgrade routine token-expiry logs (local JWT fail → remote introspection fail → refresh) from `console.warn` to `console.debug` — these are normal session lifecycle events, not errors
- Keep actual failure cases (refresh failed, refreshed tokens invalid) as `console.warn`
- Replace multi-line warnings with full error objects/stack traces with concise single-line messages

## Test plan
- [ ] Let a session expire and verify the server log only shows `[OIDC]` debug lines (not visible at default log level) instead of multi-line warnings
- [ ] Kill the OIDC provider and verify `console.warn` lines still appear for real failures
- [ ] `bun run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging and diagnostics for OpenID Connect authentication. Enhanced error messages with clearer prefixes for better troubleshooting and debugging of token validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->