### PR TITLE
feat (Frontend): Add id column to badge CSV export

### DIFF
--- a/src/routes/(authenticated)/management/[conferenceId]/downloads/BadgeData.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/downloads/BadgeData.svelte
@@ -126,6 +126,7 @@
 			countryAlpha2Code?: string | null;
 			alternativeImage?: string | null;
 			pronouns?: string | null;
+			id?: string | null;
 			mediaConsentStatus?: MediaConsentStatus$options;
 		}[],
 		filename: string
@@ -137,6 +138,7 @@
 			'countryAlpha2Code',
 			'alternativeImage',
 			'pronouns',
+			'id',
 			'mediaConsentStatus'
 		];
 		const data = badgeData.map((x) => [
@@ -146,6 +148,7 @@
 			x.countryAlpha2Code ?? '',
 			x.alternativeImage ?? '',
 			x.pronouns ?? '',
+			x.id ?? '',
 			x.mediaConsentStatus ?? 'NOT_SET'
 		]);
 		downloadCSV(header, data, filename);
@@ -177,6 +180,7 @@
 					countryAlpha2Code: member.delegation.assignedNation!.alpha2Code,
 					alternativeImage: '',
 					pronouns: member.user.pronouns,
+					id: member.user.id,
 					mediaConsentStatus:
 						member.user.conferenceParticipantStatus.find((conference) => {
 							return conference.conference.id === conferenceId;
@@ -215,6 +219,7 @@
 					countryAlpha2Code: 'un',
 					alternativeImage: '',
 					pronouns: member.user.pronouns,
+					id: member.user.id,
 					mediaConsentStatus:
 						member.user.conferenceParticipantStatus.find((conference) => {
 							return conference.conference.id === conferenceId;
@@ -252,6 +257,7 @@
 					countryAlpha2Code: 'un',
 					alternativeImage: '',
 					pronouns: member.user.pronouns,
+					id: member.user.id,
 					mediaConsentStatus:
 						member.user.conferenceParticipantStatus.find((conference) => {
 							return conference.conference.id === conferenceId;


### PR DESCRIPTION
## Summary
- Adds the `id` column to the badge data CSV export, aligning it with the updated input schema of the [badge generator](https://github.com/DeutscheModelUnitedNations/badgeGenerator)
- The `id` field contains the user ID and is used for barcode generation on vertical badges
- Applied to all three export categories: committee delegates, NSAs, and single participants

## Test plan
- [ ] Download a committee badge CSV and verify the `id` column is present with user IDs
- [ ] Download the NSA badge CSV and verify the `id` column is present
- [ ] Download the single participants badge CSV and verify the `id` column is present
- [ ] Import a generated CSV into the badge generator and confirm it passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Badge CSV exports now include a user ID column for each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->