### PR TITLE
ci: add PR lint workflow

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: PR Lint
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize, edited]
 
 jobs:
@@ -27,12 +27,12 @@ jobs:
               'PR: Tests',
             ];
 
-            const TITLE_REGEX = /^(feat|fix|style|refactor|perf|docs|test|chore|build|ci|deps)(\s*\(.+\))?\s*:\s*.+/;
-
             const ALLOWED_TYPES = [
               'feat', 'fix', 'style', 'refactor', 'perf',
               'docs', 'test', 'chore', 'build', 'ci', 'deps',
             ];
+
+            const TITLE_REGEX = new RegExp(`^(${ALLOWED_TYPES.join('|')})(\\s*\\(.+\\))?\\s*:\\s*.+$`);
 
             // --- Collect errors ---
 
@@ -68,7 +68,7 @@ jobs:
 
             // --- Find existing comment ---
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,


### PR DESCRIPTION
## Summary
- Adds a `pr-lint.yml` GitHub Actions workflow that checks PRs for required labels and conventional commit title format
- Posts a consolidated comment explaining what's wrong; auto-deletes when all checks pass
- Testing without a label to verify the comment behavior

## Test plan
- [ ] Verify workflow runs and fails (no label assigned)
- [ ] Verify comment is posted with label + title guidance
- [ ] Add label and verify comment is deleted + check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull request validation that checks PR titles and required labels, provides an up-to-date comment on the pull request with any linting issues, and fails the workflow when checks do not pass. When all checks pass, the feedback comment is removed and an informational success is recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->