### PR TITLE
fix (Frontend): Fix chase data export missing data and broken references

### DIFF
--- a/src/routes/(authenticated)/management/[conferenceId]/downloads/ChaseDataExport.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/downloads/ChaseDataExport.svelte
@@ -147,7 +147,7 @@
 
 			// Build committeeMembers: one per unique (nation, committee) pair
 			// Multiple delegates from the same nation in the same committee share one committeeMember
-			const committeeMemberIdMap = new Map<string, string>();
+			const committeeMemberIdMap = new SvelteMap<string, string>();
 			const committeeMembers: {
 				id: string;
 				representationId: string | undefined;


### PR DESCRIPTION
## Summary
- Export committee agenda items instead of hardcoded empty array
- Deduplicate `committeeMembers` to one entry per unique nation-committee pair, so multiple delegates from the same nation share a single `committeeMember` (matching the NSA/`conferenceMember` pattern)
- Only include delegates with committee assignments in `conferenceUsers` to prevent broken `committeeMemberId` references
- Export assigned single participants as `SPECTATOR` conferenceUsers
- Remove unused `individualApplicationOptions` from GraphQL query

## Test plan
- [ ] Trigger a chase data export from the downloads page
- [ ] Verify `agendaItems` array is populated with committee agenda items
- [ ] Verify `committeeMembers` contains one entry per nation-committee pair (not per delegate)
- [ ] Verify all delegate `conferenceUsers` have a `committeeMemberId` that exists in `committeeMembers`
- [ ] Verify no delegates without committee assignments appear in `conferenceUsers`
- [ ] Verify assigned single participants appear as `SPECTATOR` in `conferenceUsers`
- [ ] Import the JSON into chase and confirm it passes Zod validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conference data exports now include agenda items organized by committee.
  * Export structure expanded to include representation data mapping delegations and non-state actors.
  * Committee member assignments now exported with unique identifiers for enhanced tracking.
  * Conference user exports now provide comprehensive role information including delegates, admin/team members, spectators, and non-state actor representatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->