### PR TITLE
fix (management): search/query validation to compare IDs instead of checking existence

### DIFF
--- a/src/routes/(authenticated)/management/[conferenceId]/payments/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/payments/+page.svelte
@@ -126,7 +126,7 @@
 		const searchVal = $params.searchValue;
 		if (
 			searchVal &&
-			$paymentReferenceByIdQuery.data?.findUniquePaymentTransaction &&
+			$paymentReferenceByIdQuery.data?.findUniquePaymentTransaction?.id === searchVal &&
 			!$paymentReferenceByIdQuery.fetching
 		) {
 			lastLoadedReference = searchVal;
@@ -178,6 +178,7 @@
 	};
 
 	const resetView = () => {
+		recieveDate = new Date().toISOString().split('T')[0];
 		showPaymentDrawer = false;
 		$params.searchValue = '';
 		setTimeout(() => {

--- a/src/routes/(authenticated)/management/[conferenceId]/postalRegistration/+page.svelte
+++ b/src/routes/(authenticated)/management/[conferenceId]/postalRegistration/+page.svelte
@@ -91,7 +91,7 @@
 	});
 	$effect(() => {
 		const queryId = $params.queryUserId;
-		if (queryId && $userData?.data?.findUniqueUser && !$userData.fetching) {
+		if (queryId && $userData?.data?.findUniqueUser?.id === queryId && !$userData.fetching) {
 			lastLoadedUserId = queryId;
 			showUserDrawer = true;
 		}


### PR DESCRIPTION
## Summary
This PR fixes a bug in the payment and postal registration management pages where search/query validation was only checking for the existence of data rather than verifying that the loaded data matches the requested ID.

## Key Changes
- **Payments page**: Updated the condition in `$paymentReferenceByIdQuery` to explicitly compare the returned payment transaction ID with the search value, ensuring the correct payment record was loaded before proceeding
- **Postal Registration page**: Updated the condition in `$userData` query to explicitly compare the returned user ID with the query parameter, ensuring the correct user record was loaded
- **Payments page**: Added initialization of `recieveDate` to today's date in the `resetView()` function to ensure a valid default date when resetting the payment drawer

## Implementation Details
The fix changes the validation logic from:
```javascript
$paymentReferenceByIdQuery.data?.findUniquePaymentTransaction &&
```
to:
```javascript
$paymentReferenceByIdQuery.data?.findUniquePaymentTransaction?.id === searchVal &&
```

This ensures that the loaded record actually matches what was requested, preventing potential issues where stale or incorrect data could be used.

https://claude.ai/code/session_01YGXFvWXiFPq9KRzUH4irxs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment drawer now opens only when searching for an exact transaction ID match, preventing unintended drawer triggers
  * Postal registration drawer improved to reliably sync with URL parameters for consistent user experience
  * Default date is now set when resetting payment views for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->