### PR TITLE
fix: typo in TeamInvitationEmail template

### DIFF
--- a/src/lib/emails/templates/TeamInvitationEmail.svelte
+++ b/src/lib/emails/templates/TeamInvitationEmail.svelte
@@ -34,7 +34,7 @@
 				<Text style="font-size: 16px; color: #374151; line-height: 1.6;">
 					{inviterName} hat dich eingeladen, dich als Teammitglied der Konferenz
 					<strong>{conferenceTitle}</strong>
-					als <strong>{roleName}</strong> zu akreditieren.
+					als <strong>{roleName}</strong> zu akkreditieren.
 				</Text>
 
 				<Text style="font-size: 16px; color: #374151; line-height: 1.6;">


### PR DESCRIPTION
It's called “akkreditieren” not “akreditieren” in German

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a spelling correction in team invitation emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->