### PR TITLE
fix: impersonation fails on self-hosted Logto (JWKS key mismatch)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,14 @@ NODE_ENV=development
 # [OPTIONAL] Server port (default: 3000)
 PORT=3000
 
+# [OPTIONAL] Public origin of the application (e.g. https://delegator.munify.cloud)
+# SvelteKit uses this for CSRF protection on form submissions and POST requests.
+# If not set, SvelteKit infers it from the Host header, which works when your reverse
+# proxy forwards headers correctly (e.g. Traefik, Caddy). If you're self-hosting behind
+# a proxy that doesn't reliably set the Host header, set this to your public URL to
+# prevent CSRF validation failures.
+# ORIGIN=https://delegator.munify.cloud
+
 # ───────────────────────────────────────────────────────────────────────────────
 # DATABASE
 # ───────────────────────────────────────────────────────────────────────────────
@@ -93,14 +101,24 @@ OIDC_SCOPES="openid profile offline_access email phone identity role custom_data
 # With the custom JWT claims above, roles are available at the "roles" claim
 OIDC_ROLE_CLAIM=roles
 
+# [OPTIONAL] OIDC resource indicator for your application's API
+# When set, this is passed as the `resource` parameter during authorization and token requests,
+# and used as the expected `audience` when verifying access tokens.
+# Required for features that need API access tokens (e.g. reading resources with "resource:read"
+# scopes). Without it, Logto issues opaque tokens instead of JWTs, and access token verification
+# will be skipped.
+# Set this to the API resource indicator you configured in Logto Console → API Resources.
+# OIDC_RESOURCE=https://delegator.munify.cloud/api
+
 # [OPTIONAL] Machine-to-machine app credentials for Logto Management API
 # Required for user impersonation feature (token exchange via subject tokens)
 # Create an M2M app in Logto Console with access to the Management API resource
 # OIDC_M2M_CLIENT_ID=your-m2m-app-id
 # OIDC_M2M_CLIENT_SECRET=your-m2m-app-secret
-# [OPTIONAL] Logto Management API resource indicator
+# [OPTIONAL] Logto Management API resource indicator (audience claim in the M2M token)
+# This is NOT the API URL — the actual API URL is always derived from PUBLIC_OIDC_AUTHORITY.
 # For Logto Cloud: https://<tenant-id>.logto.app/api
-# For self-hosted: check your Logto API Resources settings (e.g. https://default.logto.app/api)
+# For self-hosted: check your Logto API Resources settings (typically https://default.logto.app/api)
 # If not set, derived from PUBLIC_OIDC_AUTHORITY by replacing /oidc with /api
 # OIDC_M2M_RESOURCE=https://default.logto.app/api
 

--- a/src/api/services/OIDC.ts
+++ b/src/api/services/OIDC.ts
@@ -285,9 +285,9 @@ async function getM2MAccessToken(): Promise<string> {
 		);
 	}
 
-	// Use configured resource or derive from OIDC authority
-	// For Logto Cloud: https://<tenant>.logto.app/api
-	// For self-hosted: must be set explicitly via OIDC_M2M_RESOURCE
+	// Resource indicator (audience claim) — may differ from the actual API URL.
+	// For self-hosted Logto the default resource identifier is https://default.logto.app/api
+	// but the actual API lives at the instance's own origin.
 	const issuer = config.serverMetadata().issuer;
 	const managementApiResource =
 		configPrivate.OIDC_M2M_RESOURCE ?? `${issuer.replace(/\/oidc\/?$/, '')}/api`;
@@ -324,12 +324,12 @@ async function getM2MAccessToken(): Promise<string> {
 async function createSubjectToken(subjectUserId: string): Promise<string> {
 	const m2mToken = await getM2MAccessToken();
 
-	// Use configured resource or derive from OIDC authority (mirrors getM2MAccessToken)
+	// The actual API URL is always derived from the issuer (the real instance origin),
+	// NOT from OIDC_M2M_RESOURCE which is only a resource indicator / audience claim.
 	const issuer = config.serverMetadata().issuer;
-	const managementApiBase =
-		configPrivate.OIDC_M2M_RESOURCE ?? `${issuer.replace(/\/oidc\/?$/, '')}/api`;
+	const managementApiUrl = `${issuer.replace(/\/oidc\/?$/, '')}/api`;
 
-	const response = await fetch(`${managementApiBase}/subject-tokens`, {
+	const response = await fetch(`${managementApiUrl}/subject-tokens`, {
 		method: 'POST',
 		headers: {
 			Authorization: `Bearer ${m2mToken}`,


### PR DESCRIPTION
## Summary
- **Fix**: `createSubjectToken` was using `OIDC_M2M_RESOURCE` (a resource indicator like `https://default.logto.app/api`) as the actual Management API URL. On self-hosted Logto, this sent requests to Logto Cloud instead of the local instance, causing `ERR_JWKS_NO_MATCHING_KEY` because the token signature couldn't be verified.
- **Fix**: The Management API URL is now always derived from the OIDC issuer (e.g. `https://guard.munify.cloud/oidc` → `https://guard.munify.cloud/api`), while `OIDC_M2M_RESOURCE` is correctly used only as the audience claim in M2M token requests.
- **Docs**: Added missing `OIDC_RESOURCE` and `ORIGIN` env vars to `.env.example`, and clarified that `OIDC_M2M_RESOURCE` is a resource indicator, not an API URL.

## Test plan
- [x] Existing tests pass (119/119)
- [ ] Verify impersonation works on self-hosted Logto with `OIDC_M2M_RESOURCE=https://default.logto.app/api`
- [ ] Verify impersonation still works on Logto Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ORIGIN` environment variable for explicit application origin configuration
  * Added `OIDC_RESOURCE` environment variable for OIDC resource indicator customization

* **Chores**
  * Improved OIDC configuration documentation and clarity
  * Enhanced Management API endpoint resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->