### PR TITLE
fix (API): allow participant care and project management to read waiting list users

### DIFF
--- a/src/api/abilities/entities/user.ts
+++ b/src/api/abilities/entities/user.ts
@@ -182,6 +182,26 @@ export const defineAbilitiesForUserEntity = (oidc: OIDC, { can }: AbilityBuilder
 			}
 		});
 
+		// team members should see users on the waiting list in the conferences they manage
+		can(['list', 'read'], 'User', {
+			waitingListEntry: {
+				some: {
+					conference: {
+						teamMembers: {
+							some: {
+								role: {
+									in: ['PARTICIPANT_CARE', 'PROJECT_MANAGEMENT']
+								},
+								user: {
+									id: user.sub
+								}
+							}
+						}
+					}
+				}
+			}
+		});
+
 		// supervisors should be able to see each other if the supervise the same delegate or single participant
 		can(['list', 'read'], 'User', {
 			OR: [


### PR DESCRIPTION
Closes #418

https://claude.ai/code/session_01MAkLVXpVLLM9E9puoTWdxB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conference organizers and project managers can now view and access information about attendees on waiting lists within their managed conferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->