### PR TITLE
fix: Allow team members to delete conference participant status

### DIFF
--- a/src/api/abilities/entities/conferenceParticipantStatus.ts
+++ b/src/api/abilities/entities/conferenceParticipantStatus.ts
@@ -74,8 +74,8 @@ export const defineAbilitiesForConferenceParticipantStatus = (
 			}
 		});
 
-		// if the user is a team member with the PARTICIPANT_CARE or PROJECT_MANAGEMENT role, they should be able to update the status
-		can(['read', 'list', 'update'], 'ConferenceParticipantStatus', {
+		// if the user is a team member with the PARTICIPANT_CARE or PROJECT_MANAGEMENT role, they should be able to update and delete the status
+		can(['read', 'list', 'update', 'delete'], 'ConferenceParticipantStatus', {
 			conference: {
 				teamMembers: {
 					some: {


### PR DESCRIPTION
## Summary
Updated the ability rules for conference participant status to grant delete permissions to team members with PARTICIPANT_CARE or PROJECT_MANAGEMENT roles.

## Changes
- Added `'delete'` action to the ability definition for ConferenceParticipantStatus
- Team members with PARTICIPANT_CARE or PROJECT_MANAGEMENT roles can now delete conference participant statuses in addition to reading, listing, and updating them
- Updated the corresponding comment to reflect the new delete capability

## Implementation Details
The change extends the existing permission check that validates team membership and role requirements. Users who already have update permissions now also have delete permissions for conference participant statuses, maintaining consistency with the existing authorization logic.

https://claude.ai/code/session_0187VfKXtsfSMn1tkEy34K3s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled deletion permissions for `ConferenceParticipantStatus` records for conference team members with `PARTICIPANT_CARE` or `PROJECT_MANAGEMENT` roles. These users can now delete participant status information alongside their existing read, list, and update capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->