### PR TITLE
fix: Increase request body size limit for file uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,14 @@ NODE_ENV=development
 # [OPTIONAL] Server port (default: 3000)
 PORT=3000
 
+# [OPTIONAL] Maximum request body size for the Node server (default: 512K)
+# adapter-node rejects larger request bodies with HTTP 413 before they reach the app,
+# which silently breaks file uploads (conference base PDFs / images can be several MB;
+# the Zod schema validates base PDFs up to 10MB each, and one save may include several).
+# Set this above the largest expected upload. Accepts K/M/G suffixes; "Infinity" disables.
+# Not enforced by the Vite dev server — only by the production (adapter-node) build.
+# BODY_SIZE_LIMIT=64M
+
 # [OPTIONAL] Public origin of the application (e.g. https://delegator.munify.cloud)
 # SvelteKit uses this for CSRF protection on form submissions and POST requests.
 # If not set, SvelteKit infers it from the Host header, which works when your reverse

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,11 @@ RUN bun run build:app && bun run check
 
 USER bun
 ENV NODE_ENV=production
+# adapter-node caps request bodies at 512K by default and rejects anything larger with
+# HTTP 413 before the request reaches the app. Conference document/image uploads (base
+# PDFs are validated up to 10MB each in the Zod schema, and several can be sent in one
+# save) exceed that. Raise the limit so uploads actually reach the server. Overridable at
+# runtime via the BODY_SIZE_LIMIT env var (see .env.example).
+ENV BODY_SIZE_LIMIT=64M
 EXPOSE 3000/tcp
 CMD ["sh", "-c", "bunx prisma migrate deploy && bun ./build/index.js"]


### PR DESCRIPTION
## Summary

Increases the default request body size limit from 512K to 64M to accommodate conference document and image uploads that can exceed the default adapter-node limit.

## Problem

The adapter-node runtime caps request bodies at 512K by default and rejects larger payloads with HTTP 413 before they reach the application. This silently breaks file uploads for conference base PDFs and images, which can be several MB in size. The Zod schema validates base PDFs up to 10MB each, and a single save operation may include multiple documents.

## Changes

- **`.env.example`**: Added `BODY_SIZE_LIMIT` configuration option with documentation explaining:
  - Default behavior (512K limit enforced by adapter-node)
  - Why the limit needs to be raised (multi-MB document uploads)
  - Accepted format (K/M/G suffixes, "Infinity" to disable)
  - Note that this only affects production builds (not Vite dev server)

- **`Dockerfile`**: Set `ENV BODY_SIZE_LIMIT=64M` as the production default to ensure file uploads work out-of-the-box while remaining overridable at runtime via environment variables

## Implementation Details

- The limit is only enforced by adapter-node in production builds; the Vite dev server is unaffected
- 64M was chosen as a reasonable default that accommodates multiple large PDFs per upload while remaining conservative
- The setting is fully documented and can be adjusted per deployment via environment variables

https://claude.ai/code/session_018FeiSjMv4pDn6p81zqPYqP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for request body size limits.
  * Increased the default limit to support larger document and image uploads.
  * Added guidance for customizing the limit, including supported units and disabling the limit.

* **Documentation**
  * Documented when request size limits apply and how oversized requests may result in HTTP 413 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->